### PR TITLE
Fixing aemSync for subprojects

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/vlt/VltApp.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/vlt/VltApp.kt
@@ -16,7 +16,7 @@ class VltApp(val instance: AemInstance, val project: Project) : VaultFsApp() {
         fun checkout(project: Project, config: AemConfig) {
             val contentDir = File(config.determineContentPath(project))
             if (!contentDir.exists()) {
-                project.logger.info("JCR content directory to be checkout out does not exist: ${contentDir.absolutePath}")
+                project.logger.info("JCR content directory to be checked out does not exist: ${contentDir.absolutePath}")
             }
 
             val instance = AemInstance.filter(project, config, AemInstance.FILTER_AUTHOR).first()
@@ -27,10 +27,9 @@ class VltApp(val instance: AemInstance, val project: Project) : VaultFsApp() {
             if (filter.exists()) {
                 vltApp.executeCommand(listOf(CheckoutTask.COMMAND, "-f", filter.absolutePath) + cmdArgs)
             } else {
-                vltApp.executeCommand(listOf(CheckoutTask.COMMAND + cmdArgs))
+                vltApp.executeCommand(listOf(CheckoutTask.COMMAND) + cmdArgs)
             }
         }
-
     }
 
     init {

--- a/src/main/kotlin/com/cognifide/gradle/aem/vlt/VltApp.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/vlt/VltApp.kt
@@ -14,9 +14,14 @@ class VltApp(val instance: AemInstance, val project: Project) : VaultFsApp() {
     companion object {
 
         fun checkout(project: Project, config: AemConfig) {
+            val contentDir = File(config.determineContentPath(project))
+            if (!contentDir.exists()) {
+                project.logger.info("JCR content directory to be checkout out does not exist: ${contentDir.absolutePath}")
+            }
+
             val instance = AemInstance.filter(project, config, AemInstance.FILTER_AUTHOR).first()
             val vltApp = VltApp(instance, project)
-            val cmdArgs = config.vaultCheckoutArgs + listOf(instance.url, "/", config.determineContentPath(project))
+            val cmdArgs = config.vaultCheckoutArgs + listOf(instance.url, "/", contentDir.absolutePath)
 
             val filter = File(config.vaultFilterPath)
             if (filter.exists()) {

--- a/src/main/kotlin/com/cognifide/gradle/aem/vlt/VltCleaner.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/vlt/VltCleaner.kt
@@ -12,7 +12,7 @@ import java.io.File
 import java.io.IOException
 import java.util.*
 
-class VltCleaner(val root: String, val logger: Logger) {
+class VltCleaner(val root: File, val logger: Logger) {
 
     companion object {
         val VLT_FILE = ".vlt"
@@ -20,22 +20,27 @@ class VltCleaner(val root: String, val logger: Logger) {
         val JCR_CONTENT_FILE = ".content.xml"
 
         fun clean(project : Project, config : AemConfig) {
-            val cleaner = VltCleaner(config.contentPath, project.logger)
+            val contentDir = File(config.determineContentPath(project))
+            if (!contentDir.exists()) {
+                project.logger.warn("JCR content directory to be cleaned does not exist: ${contentDir.absolutePath}")
+                return
+            }
 
+            val cleaner = VltCleaner(contentDir, project.logger)
             cleaner.removeVltFiles()
             cleaner.cleanupDotContent(config.vaultSkipProperties, config.vaultLineSeparator)
         }
     }
 
     fun removeVltFiles() {
-        for (file in FileUtils.listFiles(File(root), NameFileFilter(VLT_FILE), TrueFileFilter.INSTANCE)) {
+        for (file in FileUtils.listFiles(root, NameFileFilter(VLT_FILE), TrueFileFilter.INSTANCE)) {
             logger.info("Deleting {}", file.path)
             FileUtils.deleteQuietly(file)
         }
     }
 
     fun cleanupDotContent(contentProperties: List<String>, lineEnding : String) {
-        for (file in FileUtils.listFiles(File(root), NameFileFilter(JCR_CONTENT_FILE), TrueFileFilter.INSTANCE)) {
+        for (file in FileUtils.listFiles(root, NameFileFilter(JCR_CONTENT_FILE), TrueFileFilter.INSTANCE)) {
             try {
                 logger.info("Cleaning up {}", file.path)
 


### PR DESCRIPTION
`gradlew :example.content:aemSync`

ends with:

```
Caused by: java.lang.IllegalArgumentException: Parameter 'directory' is not a directory
        at org.apache.commons.io.FileUtils.validateListFilesParameters(FileUtils.java:545)
        at org.apache.commons.io.FileUtils.listFiles(FileUtils.java:521)

```

or

```
Checking out content from AEM
could not find jcr_root along the ancestors of C:\Users\krystian.panek\Projects\gradle-aem-example
Unexpected checkout[--force, http://localhost:4502, /, C:\Users\krystian.panek\Projects\gradle-aem-example\content\src\main\content] while processing . Type --help for more information.
Cleaning checked out JCR content
:example.content:aemSync (Thread[Daemon worker Thread 4,5,main]) completed. Took 0.171 secs.

```