### PR TITLE
incomplete classpath?

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compile 'org.dm.gradle:gradle-bundle-plugin:0.10.0'
     compile 'org.apache.jackrabbit.vault:org.apache.jackrabbit.vault:3.1.26'
     compile 'org.apache.jackrabbit.vault:vault-cli:3.1.6'
+    compile 'org.apache.jackrabbit:jackrabbit-api:2.7.4'
 
     // SCR runtime dependencies
 


### PR DESCRIPTION
Our source code contains a declaration

`QueryStatImpl stat = new QueryStatImpl();`

The aemProcessClasses task fails with

`NoClassDefFoundError:` `org/apache/jackrabbit/api/stats/QueryStat`

You can reproduce this by adding the above declaration to HelloService in the example project. This is due to the parent-first classloading used by the AntClassLoader. Adding the jackrabbit-api dependency solves this.