### PR TITLE
Allow subprojects to define their own bundlePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ defaultTasks = ['contentDeploy']
 
 apply plugin: 'cognifide.aem'
 
+project.ext {
+  // where to put the bundle in the content package (optional)
+  bundlePath = "/apps/some/folder"
+}
+
 aem {
     config {
         contentPath = "src/main/aem"

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compile 'org.dm.gradle:gradle-bundle-plugin:0.10.0'
     compile 'org.apache.jackrabbit.vault:org.apache.jackrabbit.vault:3.1.26'
     compile 'org.apache.jackrabbit.vault:vault-cli:3.1.6'
+    compile 'org.apache.jackrabbit:jackrabbit-api:2.7.4'
 
     // SCR runtime dependencies
 


### PR DESCRIPTION
We have a setup with 3 bundles: a common bundle (deployed to author and publisher), an author bundle (only deployed to author) and a publisher bundle (only deployed to publisher). This is controlled by the install folder. So a setup like this requires finer control over the bundlePath.