### PR TITLE
Default instance filter

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/AemInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/AemInstance.kt
@@ -14,7 +14,9 @@ data class AemInstance(
 
     companion object {
 
-        val FILTER_DEFAULT = PropertyParser.FILTER_DEFAULT
+        val FILTER_ANY = PropertyParser.FILTER_DEFAULT
+
+        val FILTER_LOCAL = "local-*"
 
         val FILTER_AUTHOR = "*-author"
 
@@ -35,7 +37,7 @@ data class AemInstance(
             )
         }
 
-        fun filter(project: Project, instanceFilter: String = FILTER_DEFAULT): List<AemInstance> {
+        fun filter(project: Project, instanceFilter: String = FILTER_LOCAL): List<AemInstance> {
             val config = AemConfig.of(project)
             val instanceValues = project.properties["aem.deploy.instance.list"] as String?
             if (!instanceValues.isNullOrBlank()) {

--- a/src/main/kotlin/com/cognifide/gradle/aem/deploy/SyncTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/deploy/SyncTask.kt
@@ -35,7 +35,7 @@ abstract class SyncTask : DefaultTask(), AemTask {
         deployer(DeploySynchronizer(instance, config))
     }
 
-    protected fun filterInstances(instanceGroup: String = AemInstance.FILTER_DEFAULT): List<AemInstance> {
+    protected fun filterInstances(instanceGroup: String = AemInstance.FILTER_LOCAL): List<AemInstance> {
         return AemInstance.filter(project, instanceGroup)
     }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/vlt/CheckoutTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/vlt/CheckoutTask.kt
@@ -23,7 +23,7 @@ open class CheckoutTask : DefaultTask(), AemTask {
     @TaskAction
     fun checkout() {
         logger.info("Checking out content from AEM")
-        VltCommand.checkout(project)
+        VltCommand(project).checkout()
     }
 
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/vlt/CleanTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/vlt/CleanTask.kt
@@ -23,7 +23,7 @@ open class CleanTask : DefaultTask(), AemTask {
     @TaskAction
     fun clean() {
         logger.info("Cleaning checked out JCR content")
-        VltCommand.clean(project)
+        VltCommand(project).clean()
     }
 
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/vlt/SyncTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/vlt/SyncTask.kt
@@ -23,9 +23,9 @@ open class SyncTask : DefaultTask(), AemTask {
     @TaskAction
     fun sync() {
         logger.info("Checking out content from AEM")
-        VltCommand.checkout(project)
+        VltCommand(project).checkout()
 
         logger.info("Cleaning checked out JCR content")
-        VltCommand.clean(project)
+        VltCommand(project).clean()
     }
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/vlt/VltCommand.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/vlt/VltCommand.kt
@@ -71,7 +71,8 @@ object VltCommand {
             return cmdInstance
         }
 
-        return AemInstance.filter(project, AemInstance.FILTER_AUTHOR).first()
+        return AemInstance.filter(project, AemInstance.FILTER_AUTHOR).firstOrNull()
+                ?: AemInstance.filter(project, AemInstance.FILTER_ANY).first()
     }
 
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/vlt/VltCommand.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/vlt/VltCommand.kt
@@ -77,13 +77,13 @@ class VltCommand(val project: Project) {
 
         val authorInstance = AemInstance.filter(project, AemInstance.FILTER_AUTHOR).firstOrNull()
         if (authorInstance != null) {
-            logger.info("Using instance matching filter '${AemInstance.FILTER_AUTHOR}': $authorInstance")
+            logger.info("Using first instance matching filter '${AemInstance.FILTER_AUTHOR}': $authorInstance")
             return authorInstance
         }
 
         val anyInstance = AemInstance.filter(project, AemInstance.FILTER_ANY).firstOrNull()
         if (anyInstance != null) {
-            logger.info("Using instance matching filter '${AemInstance.FILTER_ANY}': $anyInstance")
+            logger.info("Using first instance matching filter '${AemInstance.FILTER_ANY}': $anyInstance")
             return anyInstance
         }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/vlt/VltTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/vlt/VltTask.kt
@@ -27,7 +27,7 @@ open class VltTask : DefaultTask(), AemTask {
             throw VltException("Vault command cannot be blank.")
         }
 
-        VltCommand.raw(project, command!!)
+        VltCommand(project).raw(command!!)
     }
 
 }


### PR DESCRIPTION
Needed to cover case:

```
        aem {
            config {
                 instance("http://localhost:4503", "admin", "admin", "local-publish")
            }
        }
```

then `gradle :content:demo:aemSync -i` ends with `List is empty` but checking out from publish should work anyway.