### PR TITLE
Optional input dirs / Gradle API alignment

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/AemConfig.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/AemConfig.kt
@@ -334,7 +334,7 @@ open class AemConfig(project: Project) : Serializable {
                     "$contentPath/${AemPackagePlugin.VLT_PATH}"
             )
 
-            return paths.filter { !it.isBlank() }.map { File(it) }
+            return paths.filter { !it.isBlank() }.map { File(it) }.filter { it.exists() }
         }
 
     /**

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/PrepareTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/PrepareTask.kt
@@ -43,7 +43,7 @@ open class PrepareTask : DefaultTask(), AemTask {
         }
         vaultDir.mkdirs()
 
-        val dirs = config.vaultFilesDirs.filter { it.exists() }
+        val dirs = config.vaultFilesDirs
 
         if (dirs.isEmpty()) {
             logger.info("None of Vault files directories exist: $dirs. Only generated defaults will be used.")


### PR DESCRIPTION
Fix for deprecation / warning introduced in Gradle API 4.3:

```
problem was found with the configuration of task ':common:aemPrepare'. Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated and is scheduled to be removed in Gradle 5.0.
- Directory 'my-project\common\src\main\content\META-INF\vault' specified for property '$2' does not exist.
```