### PR TITLE
Fix for 'No SCR metadata' in unit tests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ buildscript {
     }
     
     dependencies {
-        classpath 'com.cognifide.gradle:aem-plugin:2.0.17'
+        classpath 'com.cognifide.gradle:aem-plugin:2.0.18'
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ AEM developer - it's time to meet Gradle! You liked or used plugin? Don't forget
 * Automated dependent packages installation from local and remote sources (SMB, SSH, HTTP(s)).
 * Smart Vault files generation (combining defaults with overiddables).
 * Embedded Vault tool for checking out and cleaning JCR content from running AEM instance.
-* OSGi Manifest customization by official [osgi](https://docs.gradle.org/current/userguide/osgi_plugin.html) plugin or feature rich [org.dm.bundle](https://github.com/TomDmitriev/gradle-bundle-plugin) plugin.
+* OSGi Manifest customization by official [OSGi plugin](https://docs.gradle.org/current/userguide/osgi_plugin.html) or feature rich [BND plugin](https://github.com/bndtools/bnd/tree/master/biz.aQute.bnd.gradle).
 * OSGi Declarative Services annotations support (instead of SCR, [see docs](http://blogs.adobe.com/experiencedelivers/experience-management/osgi/using-osgi-annotations-aem6-2/)).
 
 ## Table of contents

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.cognifide.gradle'
-version '2.0.17'
+version '2.0.18'
 description = 'Gradle AEM Plugin'
 defaultTasks = ['clean', 'publishToMavenLocal']
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/base/api/AemConfig.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/base/api/AemConfig.kt
@@ -263,6 +263,10 @@ open class AemConfig(project: Project) : Serializable {
     @Input
     var satisfyRefreshing: Boolean = false
 
+    @Incubating
+    @Input
+    var testClasspathArchive: Boolean = true
+
     /**
      * Initialize defaults that depends on concrete type of project.
      */

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
@@ -15,7 +15,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
  *
  * JVM based languages like Groovy or Kotlin must have implicitly applied 'java' plugin.
  * Projects can have only 'com.cognifide.aem.package' plugin applied intentionally to generate packages with content only.
- * Projects can have applied official 'osgi' or 'org.dm.bundle' plugins to customize OSGi manifest.
+ * Projects can have applied official almost any type of OSGi plugin to customize manifest ('osgi', 'biz.aQute.bnd.builder', 'org.dm.bundle').
  */
 class PackagePlugin : Plugin<Project> {
 
@@ -30,7 +30,7 @@ class PackagePlugin : Plugin<Project> {
 
         val VLT_PATH = "META-INF/vault"
 
-        val VLT_PROPERTIES = "${VLT_PATH}/properties.xml"
+        val VLT_PROPERTIES = "$VLT_PATH/properties.xml"
 
         val JCR_ROOT = "jcr_root"
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/jar/UpdateManifestTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/jar/UpdateManifestTask.kt
@@ -9,6 +9,7 @@ import org.gradle.api.plugins.osgi.OsgiManifest
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.tasks.Jar
 import java.io.File
 
@@ -37,6 +38,9 @@ open class UpdateManifestTask : AemDefaultTask() {
     @Internal
     val jar = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME) as Jar
 
+    @Internal
+    val test = project.tasks.getByName(Test.TASK_NAME) as Test
+
     val embeddableJars: List<File>
         @InputFiles
         get() {
@@ -45,7 +49,14 @@ open class UpdateManifestTask : AemDefaultTask() {
 
     init {
         project.afterEvaluate {
+            configureTest()
             embedJars()
+        }
+    }
+
+    private fun configureTest() {
+        if (config.testClasspathArchive) {
+            test.classpath += project.files(jar.archivePath)
         }
     }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/jar/UpdateManifestTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/jar/UpdateManifestTask.kt
@@ -3,6 +3,7 @@ package com.cognifide.gradle.aem.pkg.jar
 import com.cognifide.gradle.aem.base.api.AemDefaultTask
 import com.cognifide.gradle.aem.pkg.PackagePlugin
 import org.dm.gradle.plugins.bundle.BundleExtension
+import org.gradle.api.java.archives.Manifest
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.osgi.OsgiManifest
 import org.gradle.api.tasks.InputFiles
@@ -69,12 +70,11 @@ open class UpdateManifestTask : AemDefaultTask() {
         } else if (project.plugins.hasPlugin(BUNDLE_PLUGIN_ID)) {
             addInstruction(project.extensions.getByType(BundleExtension::class.java), name, valueProvider())
         } else {
-            project.logger.warn("Cannot apply specific OSGi instruction to JAR manifest, because neither "
-                    + "'$OSGI_PLUGIN_ID' nor '$BUNDLE_PLUGIN_ID' are applied to project '${project.name}'.")
+            addInstruction(jar.manifest, name, valueProvider())
         }
     }
 
-    private fun addInstruction(manifest: OsgiManifest, name: String, value: String) {
+    private fun addInstruction(manifest: OsgiManifest, name: String, value: String?) {
         if (!manifest.instructions.containsKey(name)) {
             if (!value.isNullOrBlank()) {
                 manifest.instruction(name, value)
@@ -83,11 +83,19 @@ open class UpdateManifestTask : AemDefaultTask() {
     }
 
     @Suppress("unchecked_cast")
-    private fun addInstruction(config: BundleExtension, name: String, value: String) {
+    private fun addInstruction(config: BundleExtension, name: String, value: String?) {
         val instructions = config.instructions as Map<String, Any>
         if (!instructions.contains(name)) {
             if (!value.isNullOrBlank()) {
                 config.instruction(name, value)
+            }
+        }
+    }
+
+    private fun addInstruction(manifest: Manifest, name: String, value: String?) {
+        if (!manifest.attributes.containsKey(name)) {
+            if (!value.isNullOrBlank()) {
+                manifest.attributes(mapOf(name to value))
             }
         }
     }

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/jar/UpdateManifestTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/jar/UpdateManifestTask.kt
@@ -15,10 +15,9 @@ import java.io.File
 
 /**
  * Update manifest being used by 'jar' task of Java Plugin.
+ * Supported OSGi related plugins are: 'osgi', 'biz.aQute.bnd.builder', 'org.dm.bundle' and others.
  *
- * Both plugins 'osgi' and 'org.dm.bundle' are supported.
- *
- * @see <https://issues.gradle.org/browse/GRADLE-1107>
+ * @see <https://github.com/bndtools/bnd/tree/master/biz.aQute.bnd.gradle>
  * @see <https://github.com/TomDmitriev/gradle-bundle-plugin>
  */
 open class UpdateManifestTask : AemDefaultTask() {

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/jar/UpdateManifestTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/jar/UpdateManifestTask.kt
@@ -39,7 +39,7 @@ open class UpdateManifestTask : AemDefaultTask() {
     val jar = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME) as Jar
 
     @Internal
-    val test = project.tasks.getByName(Test.TASK_NAME) as Test
+    val test = project.tasks.getByName(JavaPlugin.TEST_TASK_NAME) as Test
 
     val embeddableJars: List<File>
         @InputFiles

--- a/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/build.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/build.gradle
@@ -28,12 +28,17 @@ allprojects { subproject ->
         }
     }
 
-    plugins.withId 'org.dm.bundle', {
-        bundle {
-            instruction 'Bundle-Name', subproject.description
-            instruction 'Bundle-Category', 'example'
-            instruction 'Bundle-Vendor', 'Company'
+    plugins.withId 'biz.aQute.bnd.builder', {
+        jar {
+            manifest {
+                attributes([
+                        'Bundle-Name': subproject.description,
+                        'Bundle-Category': 'example',
+                        'Bundle-Vendor': 'Company'
+                ])
+            }
         }
+
         dependencies {
             compile group: 'org.slf4j', name: 'slf4j-api', version: '1.5.10'
             compile group: 'org.osgi', name: 'osgi.cmpn', version: '6.0.0'

--- a/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/common/build.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/common/build.gradle
@@ -7,7 +7,7 @@ defaultTasks = ['aemBuild']
 
 apply plugin: 'java'
 apply plugin: "kotlin"
-apply plugin: 'org.dm.bundle'
+apply plugin: 'biz.aQute.bnd.builder'
 apply plugin: 'com.cognifide.aem.package'
 
 bundle {

--- a/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/core/build.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/core/build.gradle
@@ -7,15 +7,19 @@ defaultTasks = ['aemBuild']
 
 apply plugin: 'java'
 apply plugin: "kotlin"
-apply plugin: 'org.dm.bundle'
+apply plugin: 'biz.aQute.bnd.builder'
 apply plugin: 'com.cognifide.aem.package'
 
-bundle {
-    def pkg = 'com.company.aem.example.core'
+jar {
+    manifest {
+        def pkg = 'com.company.aem.example.core'
 
-    instruction 'Bundle-SymbolicName', pkg
-    instruction 'Sling-Model-Packages', pkg
-    instruction 'Export-Package', "$pkg.*;-split-package:=merge-first"
+        attributes([
+                'Bundle-SymbolicName': pkg,
+                'Sling-Model-Packages': pkg,
+                'Export-Package': "$pkg.*;-split-package:=merge-first"
+        ])
+    }
 }
 
 dependencies {

--- a/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/gradle/buildscript.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/gradle/buildscript.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    classpath 'com.cognifide.gradle:aem-plugin:2.0.17'
-    classpath "org.dm.gradle:gradle-bundle-plugin:0.10.0"
+    classpath 'com.cognifide.gradle:aem-plugin:2.0.18'
+    classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:3.5.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.1.60"
 }

--- a/src/test/resources/com/cognifide/gradle/aem/test/compose/bundle-and-content/build.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/compose/bundle-and-content/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.cognifide.gradle:aem-plugin:2.0.17'
-        classpath 'org.dm.gradle:gradle-bundle-plugin:0.10.0'
+        classpath 'com.cognifide.gradle:aem-plugin:2.0.18'
+        classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:3.5.0'
     }
 }
 
@@ -15,9 +15,9 @@ group = 'com.company.aem'
 version = '1.0.0-SNAPSHOT'
 description = 'Example'
 
-apply plugin: 'com.cognifide.aem.package'
 apply plugin: 'java'
-apply plugin: 'org.dm.bundle'
+apply plugin: 'biz.aQute.bnd.builder'
+apply plugin: 'com.cognifide.aem.package'
 
 repositories {
     mavenLocal()
@@ -31,8 +31,12 @@ dependencies {
     compile group: 'org.osgi', name: 'osgi.cmpn', version: '6.0.0'
 }
 
-bundle {
-    instruction 'Bundle-Name', description
-    instruction 'Bundle-Category', 'example'
-    instruction 'Bundle-Vendor', 'Company'
+jar {
+    manifest {
+        attributes([
+                'Bundle-Name': description,
+                'Bundle-Category': 'example',
+                'Bundle-Vendor': 'Company'
+        ])
+    }
 }

--- a/src/test/resources/com/cognifide/gradle/aem/test/debug/build.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/debug/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.cognifide.gradle:aem-plugin:2.0.17'
+        classpath 'com.cognifide.gradle:aem-plugin:2.0.18'
     }
 }
 


### PR DESCRIPTION
Also removed warning about supported OSGI related plugins.
Now will be supported all 'osgi', 'org.dm.bundle' and 'biz.aQute.bnd.builder' :>