### PR TITLE
Configuring behavior related properties via cmd line

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ buildscript {
     }
     
     dependencies {
-        classpath 'com.cognifide.gradle:aem-plugin:2.0.18'
+        classpath 'com.cognifide.gradle:aem-plugin:2.0.20'
     }
 }
 
@@ -193,7 +193,11 @@ aem {
         awaitInterval = 1000
         awaitTimeout = 900
         awaitTimes = 300
+        awaitFail = true
+        awaitAssurances = 1
+        awaitCondition = { instanceState -> instanceState.stable }
         satisfyRefreshing = false
+        testClasspathJarIncluded = true
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ aem {
         deployParallel = true
         deploySnapshots = []
         uploadForce = true
-        recursiveInstall = true
+        installRecursive = true
         acHandling = "merge_preserve"
         contentPath = project.file("src/main/content")
         if (project == project.rootProject) {
@@ -286,7 +286,7 @@ Then file at path *build/aem/aemDebug/debug.json* with content below is being ge
       "deployParallel" : true,
       "deploySnapshots" : [ ],
       "uploadForce" : true,
-      "recursiveInstall" : true
+      "installRecursive" : true
       // ...
     },
     "requiresRoot" : "false",

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.cognifide.gradle'
-version '2.0.19'
+version '2.0.20'
 description = 'Gradle AEM Plugin'
 defaultTasks = ['clean', 'publishToMavenLocal']
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/base/api/AemConfig.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/base/api/AemConfig.kt
@@ -265,6 +265,7 @@ open class AemConfig(project: Project) : Serializable {
     /**
      * Hook for customizing condition being an instance stability check.
      */
+
     @Internal
     @get:JsonIgnore
     var awaitCondition: (InstanceState) -> Boolean = { it.stable }

--- a/src/main/kotlin/com/cognifide/gradle/aem/base/api/AemConfig.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/base/api/AemConfig.kt
@@ -1,12 +1,12 @@
 package com.cognifide.gradle.aem.base.api
 
 import com.cognifide.gradle.aem.instance.*
+import com.cognifide.gradle.aem.internal.LineSeparator
 import com.cognifide.gradle.aem.internal.PropertyParser
 import com.cognifide.gradle.aem.pkg.ComposeTask
 import com.cognifide.gradle.aem.pkg.PackagePlugin
 import com.fasterxml.jackson.annotation.JsonIgnore
 import org.gradle.api.DefaultTask
-import org.gradle.api.Incubating
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -186,13 +186,13 @@ open class AemConfig(project: Project) : Serializable {
      * Global options which are being applied to any Vault related command like 'aemVault' or 'aemCheckout'.
      */
     @Input
-    var vaultGlobalOptions: String = "--credentials {{instance.credentials}}"
+    var vaultGlobalOptions: String = propParser.string("aem.vlt.globalOptions", "--credentials {{instance.credentials}}")
 
     /**
      * Specify characters to be used as line endings when cleaning up checked out JCR content.
      */
     @Input
-    var vaultLineSeparator: String = propParser.string("aem.vlt.lineSeparator", System.lineSeparator())
+    var vaultLineSeparator: String = propParser.string("aem.vlt.lineSeparator", "LF")
 
     /**
      * Configure default task dependency assignments while including dependant project bundles.
@@ -317,19 +317,19 @@ open class AemConfig(project: Project) : Serializable {
      * Declare new deployment target (AEM instance).
      */
     fun localInstance(httpUrl: String) {
-        instance(LocalInstance(httpUrl))
+        instance(LocalInstance.create(httpUrl))
     }
 
     fun localInstance(httpUrl: String, type: String) {
-        instance(LocalInstance(httpUrl, type))
+        instance(LocalInstance.create(httpUrl, type))
     }
 
     fun localInstance(httpUrl: String, user: String, password: String) {
-        instance(LocalInstance(httpUrl, user, password))
+        instance(LocalInstance.create(httpUrl, user, password))
     }
 
     fun localInstance(httpUrl: String, user: String, password: String, type: String) {
-        instance(LocalInstance(httpUrl, user, password, type))
+        instance(LocalInstance.create(httpUrl, user, password, type))
     }
 
     fun localInstance(httpUrl: String, user: String, password: String, type: String, debugPort: Int) {
@@ -337,15 +337,15 @@ open class AemConfig(project: Project) : Serializable {
     }
 
     fun remoteInstance(httpUrl: String) {
-        instance(RemoteInstance(httpUrl))
+        instance(RemoteInstance.create(httpUrl))
     }
 
     fun remoteInstance(httpUrl: String, environment: String) {
-        instance(RemoteInstance(httpUrl, environment))
+        instance(RemoteInstance.create(httpUrl, environment))
     }
 
     fun remoteInstance(httpUrl: String, user: String, password: String, environment: String) {
-        instance(RemoteInstance(httpUrl, user, password, environment))
+        instance(RemoteInstance.create(httpUrl, user, password, environment))
     }
 
     fun remoteInstance(httpUrl: String, user: String, password: String, type: String, environment: String) {
@@ -409,6 +409,10 @@ open class AemConfig(project: Project) : Serializable {
     @get:JsonIgnore
     val vaultFilterPath: String
         get() = "$vaultPath/filter.xml"
+
+    @get:Internal
+    @get:JsonIgnore
+    val vaultLineSeparatorString: String = LineSeparator.string(vaultLineSeparator)
 
     companion object {
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/base/api/AemConfig.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/base/api/AemConfig.kt
@@ -1,6 +1,7 @@
 package com.cognifide.gradle.aem.base.api
 
 import com.cognifide.gradle.aem.instance.*
+import com.cognifide.gradle.aem.internal.PropertyParser
 import com.cognifide.gradle.aem.pkg.ComposeTask
 import com.cognifide.gradle.aem.pkg.PackagePlugin
 import com.fasterxml.jackson.annotation.JsonIgnore
@@ -24,6 +25,12 @@ import java.util.concurrent.TimeUnit
 open class AemConfig(project: Project) : Serializable {
 
     /**
+     * Allows to read project property specified in command line and system property as a fallback.
+     */
+    @Internal
+    private val propParser = PropertyParser(project)
+
+    /**
      * List of AEM instances on which packages could be deployed.
      * Instance stored in map ensures name uniqueness and allows to be referenced in expanded properties.
      */
@@ -31,36 +38,47 @@ open class AemConfig(project: Project) : Serializable {
     var instances: MutableMap<String, Instance> = mutableMapOf()
 
     /**
+     * Determines current environment to be used in deployment.
+     */
+    @Input
+    val deployEnvironment : String = propParser.string("aem.env", { System.getenv("AEM_ENV") ?: "local" })
+
+    /**
+     * Determines instances involved in CRX package deployment.
+     */
+    @Input
+    var deployInstanceName : String = propParser.string("aem.deploy.instance.name", "*-$deployEnvironment")
+
+    /**
      * Defines maximum time after which initializing connection to AEM will be aborted (e.g on upload, install).
      */
     @Input
-    var deployConnectionTimeout: Int = 5000
+    var deployConnectionTimeout: Int = propParser.int("aem.deploy.connectionTimeout", 5000)
 
     /**
      * Perform deploy action (upload, install or activate) in parallel to multiple instances at once.
      */
-    @Incubating
     @Input
-    var deployParallel: Boolean = true
+    var deployParallel: Boolean = propParser.boolean("aem.deploy.parallel", true)
 
     /**
      * CRX package name conventions (with wildcard) indicating that package can change over time
      * while having same version specified.
      */
     @Input
-    var deploySnapshots: List<String> = mutableListOf()
+    var deploySnapshots: List<String> = propParser.list("aem.deploy.snapshots")
 
     /**
      * Force upload CRX package regardless if it was previously uploaded.
      */
     @Input
-    var uploadForce: Boolean = true
+    var uploadForce: Boolean = propParser.boolean("aem.upload.force", true)
 
     /**
      * Determines if when on package install, sub-packages included in CRX package content should be also installed.
      */
     @Input
-    var recursiveInstall: Boolean = true
+    var installRecursive: Boolean = propParser.boolean("aem.install.recursive", true)
 
     /**
      * Defines behavior for access control handling included in rep:policy nodes being a part of CRX package content.
@@ -174,7 +192,7 @@ open class AemConfig(project: Project) : Serializable {
      * Specify characters to be used as line endings when cleaning up checked out JCR content.
      */
     @Input
-    var vaultLineSeparator: String = System.lineSeparator()
+    var vaultLineSeparator: String = propParser.string("aem.vlt.lineSeparator", System.lineSeparator())
 
     /**
      * Configure default task dependency assignments while including dependant project bundles.
@@ -199,7 +217,7 @@ open class AemConfig(project: Project) : Serializable {
      * Build date used as base for calculating 'created' and 'buildCount' package properties.
      */
     @Internal
-    var buildDate: Date = Date()
+    var buildDate: Date = propParser.date("aem.buildDate", Date())
 
     /**
      * Path in which local AEM instances will be stored.
@@ -227,40 +245,40 @@ open class AemConfig(project: Project) : Serializable {
      * actual operation being performed on AEM like starting JCR package installation or even creating launchpad.
      */
     @Input
-    var awaitDelay: Long = TimeUnit.SECONDS.toMillis(3)
+    var awaitDelay: Long = propParser.long("aem.await.delay", TimeUnit.SECONDS.toMillis(3))
 
     /**
      * Time in milliseconds used as interval between next instance stability checks being performed.
      * Optimization could be necessary only when instance is heavily loaded.
      */
     @Input
-    var awaitInterval: Long = TimeUnit.SECONDS.toMillis(1)
+    var awaitInterval: Long = propParser.long("aem.await.interval", TimeUnit.SECONDS.toMillis(1))
 
     /**
      * After each await interval, instance stability check is being performed.
      * This value is a HTTP connection timeout (in millis) which must be smaller than interval to avoid race condition.
      */
     @Input
-    var awaitTimeout: Int = (0.9 * awaitInterval.toDouble()).toInt()
+    var awaitTimeout: Int = propParser.int ("aem.await.timeout", (0.9 * awaitInterval.toDouble()).toInt())
 
     /**
      * Maximum intervals after which instance stability checks will
      * be skipped if there is still some unstable instance left.
      */
     @Input
-    var awaitTimes: Long = 60 * 5
+    var awaitTimes: Long = propParser.long("aem.await.times", 60 * 5)
 
     /**
      * If there is still some unstable instance left, then fail build except just logging warning.
      */
     @Input
-    var awaitFail: Boolean = true
+    var awaitFail: Boolean = propParser.boolean("aem.await.fail", true)
 
     /**
      * Number of intervals / additional instance stability checks to assure all stable instances.
      */
     @Input
-    var awaitAssurances: Long = 1
+    var awaitAssurances: Long = propParser.long("aem.await.assurances", 1L)
 
     /**
      * Hook for customizing condition being an instance stability check.
@@ -276,14 +294,15 @@ open class AemConfig(project: Project) : Serializable {
      *
      * This flag can change that behavior, so that information will be refreshed after each package installation.
      */
-    @Incubating
     @Input
-    var satisfyRefreshing: Boolean = false
+    var satisfyRefreshing: Boolean = propParser.boolean("aem.satisfy.refreshing", false)
+
+    @Input
+    var satisfyGroupName = propParser.string("aem.satisfy.group.name", "app-*,lib-*,hotfix-*,cfp-*,sp-*")
 
     /**
      * @see <https://github.com/Cognifide/gradle-aem-plugin/issues/95>
      */
-    @Incubating
     @Input
     var testClasspathJarIncluded: Boolean = true
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/base/api/AemConfig.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/base/api/AemConfig.kt
@@ -28,7 +28,7 @@ open class AemConfig(project: Project) : Serializable {
      * Allows to read project property specified in command line and system property as a fallback.
      */
     @Internal
-    private val propParser = PropertyParser(project)
+    val propParser = PropertyParser(project)
 
     /**
      * List of AEM instances on which packages could be deployed.

--- a/src/main/kotlin/com/cognifide/gradle/aem/base/vlt/VltCommand.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/base/vlt/VltCommand.kt
@@ -2,6 +2,7 @@ package com.cognifide.gradle.aem.base.vlt
 
 import com.cognifide.gradle.aem.base.api.AemConfig
 import com.cognifide.gradle.aem.instance.Instance
+import com.cognifide.gradle.aem.internal.LineSeparator
 import com.cognifide.gradle.aem.internal.PropertyParser
 import com.cognifide.gradle.aem.internal.file.FileOperations
 import org.gradle.api.Project
@@ -25,7 +26,7 @@ class VltCommand(val project: Project) {
 
         val cleaner = VltCleaner(contentDir, logger)
         cleaner.removeVltFiles()
-        cleaner.cleanupDotContent(config.vaultSkipProperties, config.vaultLineSeparator)
+        cleaner.cleanupDotContent(config.vaultSkipProperties, LineSeparator.string(config.vaultLineSeparator))
     }
 
     fun checkout() {
@@ -58,7 +59,7 @@ class VltCommand(val project: Project) {
 
     fun determineFilter(): VltFilter {
         val config = AemConfig.of(project)
-        val cmdFilterPath = propertyParser.prop("aem.vlt.filter")
+        val cmdFilterPath = propertyParser.string("aem.vlt.filter")
         val cmdFilterRoots = PropertyParser(project).list("aem.vlt.filterRoots")
 
         return if (!cmdFilterPath.isNullOrBlank()) {
@@ -77,7 +78,7 @@ class VltCommand(val project: Project) {
     }
 
     fun determineInstance(): Instance {
-        val cmdInstanceArg = propertyParser.prop("aem.vlt.instance")
+        val cmdInstanceArg = propertyParser.string("aem.vlt.instance")
         if (!cmdInstanceArg.isNullOrBlank()) {
             val cmdInstance = Instance.parse(cmdInstanceArg!!).first()
             cmdInstance.validate()

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/CreateTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/CreateTask.kt
@@ -36,12 +36,12 @@ open class CreateTask : SyncTask() {
     }
 
     private fun instanceFileFromProperties() {
-        val jarUrl = propertyParser.prop(JAR_URL_PROP)
+        val jarUrl = propertyParser.string(JAR_URL_PROP)
         if (!jarUrl.isNullOrBlank()) {
             instanceFileResolver.url(jarUrl!!)
         }
 
-        val licenseUrl = propertyParser.prop(LICENSE_URL_PROP)
+        val licenseUrl = propertyParser.string(LICENSE_URL_PROP)
         if (!licenseUrl.isNullOrBlank()) {
             instanceFileResolver.url(licenseUrl!!)
         }

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/Instance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/Instance.kt
@@ -45,7 +45,7 @@ interface Instance : Serializable {
                     }
                     3 -> {
                         val (httpUrl, user, password) = parts
-                        val type = InstanceType.byUrl(httpUrl).name.toLowerCase()
+                        val type = InstanceType.nameByUrl(httpUrl)
 
                         RemoteInstance(httpUrl, user, password, type, ENVIRONMENT_CMD)
                     }

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/InstanceSync.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/InstanceSync.kt
@@ -210,7 +210,7 @@ class InstanceSync(val project: Project, val instance: Instance) {
 
         try {
             val json = post(url, mapOf(
-                    "recursive" to config.recursiveInstall,
+                    "recursive" to config.installRecursive,
                     "acHandling" to config.acHandling
             ))
             val response = InstallResponse(json)
@@ -338,7 +338,7 @@ class InstanceSync(val project: Project, val instance: Instance) {
 
         try {
             val rawHtml = post(url, mapOf(
-                    "recursive" to config.recursiveInstall,
+                    "recursive" to config.installRecursive,
                     "acHandling" to config.acHandling
             ))
             val response = UninstallResponse(rawHtml)

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/InstanceUrl.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/InstanceUrl.kt
@@ -1,0 +1,41 @@
+package com.cognifide.gradle.aem.instance
+
+import com.cognifide.gradle.aem.base.api.AemException
+import java.net.MalformedURLException
+import java.net.URL
+
+class InstanceUrl(raw: String) {
+
+    val config = URL(raw)
+
+    val user: String
+        get() = userPart(0) ?: Instance.USER_DEFAULT
+
+    val password: String
+        get() = userPart(1) ?: Instance.PASSWORD_DEFAULT
+
+    val httpUrl: String
+        get() = "${config.protocol}://${config.host}:${config.port}"
+
+    val type: String
+        get() = InstanceType.byUrl(httpUrl).name.toLowerCase()
+
+    private fun userPart(index: Int): String? {
+        return config.userInfo?.split(":")
+                ?.takeIf { it.size == 2 }
+                ?.get(index)
+    }
+
+    companion object {
+
+        fun parse(raw: String): InstanceUrl {
+            return try {
+                InstanceUrl(raw)
+            } catch (e: MalformedURLException) {
+                throw AemException("Cannot parse instance URL: '$raw'", e)
+            }
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/InstanceUrl.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/InstanceUrl.kt
@@ -18,7 +18,7 @@ class InstanceUrl(raw: String) {
         get() = "${config.protocol}://${config.host}:${config.port}"
 
     val type: String
-        get() = InstanceType.byUrl(httpUrl).name.toLowerCase()
+        get() = InstanceType.nameByUrl(httpUrl)
 
     private fun userPart(index: Int): String? {
         return config.userInfo?.split(":")

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/LocalInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/LocalInstance.kt
@@ -24,7 +24,7 @@ class LocalInstance(
                     httpUrl,
                     user,
                     password,
-                    InstanceType.byUrl(httpUrl).name,
+                    InstanceType.nameByUrl(httpUrl),
                     debugPortByUrl(httpUrl)
             )
         }

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/LocalInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/LocalInstance.kt
@@ -18,39 +18,51 @@ class LocalInstance(
         fun debugPortByUrl(url: String): Int {
             return "1${Instance.portOfUrl(url)}".toInt()
         }
+
+        fun create(httpUrl: String, user: String, password: String): Instance {
+            return LocalInstance(
+                    httpUrl,
+                    user,
+                    password,
+                    InstanceType.byUrl(httpUrl).name,
+                    debugPortByUrl(httpUrl)
+            )
+        }
+
+        fun create(httpUrl: String, type: String): Instance {
+            val instanceUrl = InstanceUrl.parse(httpUrl)
+
+            return LocalInstance(
+                    instanceUrl.httpUrl,
+                    instanceUrl.user,
+                    instanceUrl.password,
+                    type,
+                    debugPortByUrl(httpUrl)
+            )
+        }
+
+        fun create(httpUrl: String): LocalInstance {
+            val instanceUrl = InstanceUrl.parse(httpUrl)
+
+            return LocalInstance(
+                    instanceUrl.httpUrl,
+                    instanceUrl.user,
+                    instanceUrl.password,
+                    InstanceType.nameByUrl(httpUrl),
+                    debugPortByUrl(httpUrl)
+            )
+        }
+
+        fun create(httpUrl: String, user: String, password: String, type: String): LocalInstance {
+            return LocalInstance(
+                    httpUrl,
+                    user,
+                    password,
+                    type,
+                    debugPortByUrl(httpUrl)
+            )
+        }
     }
-
-    constructor(httpUrl: String, user: String, password: String, type: String) : this(
-            httpUrl,
-            user,
-            password,
-            type,
-            debugPortByUrl(httpUrl)
-    )
-
-    constructor(httpUrl: String, user: String, password: String) : this(
-            httpUrl,
-            user,
-            password,
-            InstanceType.byUrl(httpUrl).name,
-            debugPortByUrl(httpUrl)
-    )
-
-    constructor(httpUrl: String, type: String) : this(
-            httpUrl,
-            Instance.USER_DEFAULT,
-            Instance.PASSWORD_DEFAULT,
-            type,
-            debugPortByUrl(httpUrl)
-    )
-
-    constructor(httpUrl: String) : this(
-            httpUrl,
-            Instance.USER_DEFAULT,
-            Instance.PASSWORD_DEFAULT,
-            InstanceType.nameByUrl(httpUrl),
-            debugPortByUrl(httpUrl)
-    )
 
     override val environment: String
         get() = ENVIRONMENT

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/RemoteInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/RemoteInstance.kt
@@ -12,23 +12,33 @@ class RemoteInstance(
         override val environment: String
 ) : Instance, Serializable {
 
-    constructor(httpUrl: String) : this(httpUrl, LocalInstance.ENVIRONMENT)
+    companion object {
+        fun create(httpUrl: String): RemoteInstance {
+            return create(httpUrl, LocalInstance.ENVIRONMENT)
+        }
 
-    constructor(httpUrl: String, environment: String) : this(
-            httpUrl,
-            Instance.USER_DEFAULT,
-            Instance.PASSWORD_DEFAULT,
-            InstanceType.byUrl(httpUrl).name.toLowerCase(),
-            environment
-    )
+        fun create(httpUrl: String, environment: String): RemoteInstance {
+            val instanceUrl = InstanceUrl.parse(httpUrl)
 
-    constructor(httpUrl: String, user: String, password: String, environment: String) : this(
-            httpUrl,
-            user,
-            password,
-            InstanceType.byUrl(httpUrl).name.toLowerCase(),
-            environment
-    )
+            return RemoteInstance(
+                    instanceUrl.httpUrl,
+                    instanceUrl.user,
+                    instanceUrl.password,
+                    InstanceType.byUrl(httpUrl).name.toLowerCase(),
+                    environment
+            )
+        }
+
+        fun create(httpUrl: String, user: String, password: String, environment: String): RemoteInstance {
+            return RemoteInstance(
+                    httpUrl,
+                    user,
+                    password,
+                    InstanceType.byUrl(httpUrl).name.toLowerCase(),
+                    environment
+            )
+        }
+    }
 
     override fun toString(): String {
         return "RemoteInstance(httpUrl='$httpUrl', user='$user', password='$hiddenPassword', type='$typeName', environment='$environment')"

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/RemoteInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/RemoteInstance.kt
@@ -24,7 +24,7 @@ class RemoteInstance(
                     instanceUrl.httpUrl,
                     instanceUrl.user,
                     instanceUrl.password,
-                    InstanceType.byUrl(httpUrl).name.toLowerCase(),
+                    instanceUrl.type,
                     environment
             )
         }
@@ -34,7 +34,7 @@ class RemoteInstance(
                     httpUrl,
                     user,
                     password,
-                    InstanceType.byUrl(httpUrl).name.toLowerCase(),
+                    InstanceType.nameByUrl(httpUrl),
                     environment
             )
         }

--- a/src/main/kotlin/com/cognifide/gradle/aem/internal/LineSeparator.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/internal/LineSeparator.kt
@@ -1,0 +1,21 @@
+package com.cognifide.gradle.aem.internal
+
+/**
+ * @see <https://en.wikipedia.org/wiki/Newline#Representations_in_different_character_encoding_specifications>
+ */
+enum class LineSeparator(val value: String) {
+
+    LF("\n"),
+    CRLF("\r\n"),
+    CR("\r"),
+    LFCR("\n\r");
+
+    companion object {
+
+        fun string(name: String): String {
+            return values().find { it.name.equals(name, true) }?.value
+                    ?: throw IllegalArgumentException("Unsupported line separator specified: $name. Valid are: ${values()}")
+        }
+
+    }
+}

--- a/src/main/kotlin/com/cognifide/gradle/aem/internal/PropertyParser.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/internal/PropertyParser.kt
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.text.StrSubstitutor
 import org.gradle.api.Project
 import java.io.StringWriter
 import java.text.SimpleDateFormat
+import java.util.*
 
 class PropertyParser(val project: Project) {
 
@@ -45,7 +46,7 @@ class PropertyParser(val project: Project) {
         }
     }
 
-    fun prop(name: String): String? {
+    private fun prop(name: String): String? {
         var value = project.properties[name] as String?
         if (value == null) {
             value = systemProperties[name]
@@ -65,7 +66,33 @@ class PropertyParser(val project: Project) {
         return between.split(delimiter)
     }
 
-    fun prop(name: String, defaultValue: () -> String): String {
+    fun date(name: String, defaultValue: Date): Date {
+        val timestamp = prop(name)
+
+        return if (timestamp.isNullOrBlank()) {
+            defaultValue
+        } else {
+            Date(timestamp!!.toLong())
+        }
+    }
+
+    fun boolean(name: String, defaultValue: Boolean): Boolean {
+        return prop(name)?.toBoolean() ?: defaultValue
+    }
+
+    fun long(name: String, defaultValue: Long): Long {
+        return prop(name)?.toLong() ?: defaultValue
+    }
+
+    fun int(name: String, defaultValue: Int): Int {
+        return prop(name)?.toInt() ?: defaultValue
+    }
+
+    fun string(name: String, defaultValue: String): String {
+        return prop(name) ?: defaultValue
+    }
+
+    fun string(name: String, defaultValue: () -> String): String {
         return prop(name) ?: defaultValue()
     }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/internal/PropertyParser.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/internal/PropertyParser.kt
@@ -88,6 +88,8 @@ class PropertyParser(val project: Project) {
         return prop(name)?.toInt() ?: defaultValue
     }
 
+    fun string(name: String) = prop(name)
+
     fun string(name: String, defaultValue: String): String {
         return prop(name) ?: defaultValue
     }

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/ComposeTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/ComposeTask.kt
@@ -3,6 +3,7 @@ package com.cognifide.gradle.aem.pkg
 import com.cognifide.gradle.aem.base.api.AemConfig
 import com.cognifide.gradle.aem.base.api.AemException
 import com.cognifide.gradle.aem.base.api.AemTask
+import com.cognifide.gradle.aem.internal.LineSeparator
 import com.cognifide.gradle.aem.internal.Patterns
 import com.cognifide.gradle.aem.internal.PropertyParser
 import org.gradle.api.Project
@@ -64,7 +65,7 @@ open class ComposeTask : Zip(), AemTask {
 
     @get:Internal
     val fileProperties
-        get() = mapOf("filterRoots" to filterRoots.joinToString(config.vaultLineSeparator))
+        get() = mapOf("filterRoots" to filterRoots.joinToString(LineSeparator.string(config.vaultLineSeparator)))
 
     init {
         description = "Composes CRX package from JCR content and built OSGi bundles"

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/deploy/SyncTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/deploy/SyncTask.kt
@@ -38,7 +38,11 @@ abstract class SyncTask : AemDefaultTask() {
         }
     }
 
-    protected fun filterInstances(instanceGroup: String = Instance.FILTER_LOCAL): List<Instance> {
+    protected fun filterInstances(): List<Instance> {
+        return Instance.filter(project)
+    }
+
+    protected fun filterInstances(instanceGroup: String): List<Instance> {
         return Instance.filter(project, instanceGroup)
     }
 

--- a/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/common/build.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/common/build.gradle
@@ -10,12 +10,16 @@ apply plugin: "kotlin"
 apply plugin: 'biz.aQute.bnd.builder'
 apply plugin: 'com.cognifide.aem.package'
 
-bundle {
-    def pkg = 'com.company.aem.example.common'
+jar {
+    manifest {
+        def pkg = 'com.company.aem.example.common'
 
-    instruction 'Bundle-SymbolicName', pkg
-    instruction 'Sling-Model-Packages', pkg
-    instruction 'Export-Package', "$pkg.*;-split-package:=merge-first,org.hashids.*"
+        attributes([
+                'Bundle-SymbolicName': pkg,
+                'Sling-Model-Packages': pkg,
+                'Export-Package': "$pkg.*;-split-package:=merge-first,org.hashids.*"
+        ])
+    }
 }
 
 dependencies {

--- a/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/gradle/buildscript.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/gradle/buildscript.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    classpath 'com.cognifide.gradle:aem-plugin:2.0.18'
+    classpath 'com.cognifide.gradle:aem-plugin:2.0.20'
     classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:3.5.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.1.60"
 }

--- a/src/test/resources/com/cognifide/gradle/aem/test/compose/bundle-and-content/build.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/compose/bundle-and-content/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.cognifide.gradle:aem-plugin:2.0.18'
+        classpath 'com.cognifide.gradle:aem-plugin:2.0.20'
         classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:3.5.0'
     }
 }

--- a/src/test/resources/com/cognifide/gradle/aem/test/debug/build.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/debug/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.cognifide.gradle:aem-plugin:2.0.18'
+        classpath 'com.cognifide.gradle:aem-plugin:2.0.20'
     }
 }
 


### PR DESCRIPTION
Also implemented:

* line separator by name / abbreviation
* default deploy instance name configurable (instead of hardcoded '*-local'), #64 
* instance url containing user and password, #107 