### PR TITLE
Java incremental hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ buildscript {
     }
     
     dependencies {
-        classpath 'com.cognifide.gradle:aem-plugin:3.0.5'
+        classpath 'com.cognifide.gradle:aem-plugin:3.0.6-SNAPSHOT'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.cognifide.gradle'
-version '3.0.5'
+version '3.0.6-SNAPSHOT'
 description = 'Gradle AEM Plugin'
 defaultTasks = ['clean', 'build', 'publishToMavenLocal']
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundleCollector.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundleCollector.kt
@@ -1,6 +1,5 @@
 package com.cognifide.gradle.aem.bundle
 
-import aQute.bnd.osgi.Jar
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
@@ -27,17 +26,10 @@ class BundleCollector(val project: Project) {
     val allJars: Collection<File>
         get() {
             val jars = TreeSet<File>()
+
             archiveConfig?.apply { jars += allArtifacts.files.files }
-            installConfig?.apply { jars += resolve().toList() }
+            installConfig?.apply { jars += resolve() }
 
-            return jars.filter { isOsgiBundle(it) }
+            return jars.filter { it.extension == "jar" }
         }
-
-    private fun isOsgiBundle(it: File): Boolean {
-        return try {
-            !Jar(it).manifest.mainAttributes.getValue("Bundle-SymbolicName").isNullOrBlank()
-        } catch (e: Exception) {
-            false
-        }
-    }
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/InstanceActions.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/InstanceActions.kt
@@ -83,37 +83,31 @@ class InstanceActions(val project: Project) {
     }
 
     private fun progressFor(states: List<InstanceState>, timer: Behaviors.Timer) =
-            (progressTicks(timer.ticks, 0) + " " + states.joinToString(" | ") { progressFor(it, timer.ticks) }).trim()
+            (progressTicks(timer.ticks, 0) + " " + states.joinToString(" | ") { progressFor(it) }).trim()
 
     private fun progressFor(states: List<InstanceState>, config: AemConfig, timer: Behaviors.Timer) =
-            (progressTicks(timer.ticks, config.awaitTimes) + " " + states.joinToString(" | ") { progressFor(it, timer.ticks) }).trim()
+            (progressTicks(timer.ticks, config.awaitTimes) + " " + states.joinToString(" | ") { progressFor(it) }).trim()
 
-    private fun progressFor(state: InstanceState, tick: Long): String {
-        return "${state.instance.name}: ${progressIndicator(state, tick)} ${state.bundleState.statsWithLabels} [${state.bundleState.stablePercent}]"
+    private fun progressFor(state: InstanceState): String {
+        return "${state.instance.name}: ${progressIndicator(state)} ${state.bundleState.statsWithLabels} [${state.bundleState.stablePercent}]"
     }
 
     private fun progressTicks(tick: Long, maxTicks: Long): String {
         return if (maxTicks > 0 && (tick.toDouble() / maxTicks.toDouble() > 0.1)) {
             "[$tick/$maxTicks tt]"
+        } else if (tick.rem(2) == 0L) {
+            "[*]"
         } else {
-            ""
+            "[ ]"
         }
     }
 
-    private fun progressIndicator(state: InstanceState, tick: Long): String {
-        var indicator = if (tick.rem(2) == 0L) {
-            if (state.config.awaitCondition(state)) {
-                "+"
-            } else {
-                "-"
-            }
+    private fun progressIndicator(state: InstanceState): String {
+        return if (state.config.awaitCondition(state)) {
+            "+"
         } else {
-            " "
+            "-"
         }
-
-
-
-        return indicator
     }
 
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/ComposeTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/ComposeTask.kt
@@ -1,5 +1,6 @@
 package com.cognifide.gradle.aem.pkg
 
+import aQute.bnd.osgi.Jar
 import com.cognifide.gradle.aem.api.AemConfig
 import com.cognifide.gradle.aem.api.AemException
 import com.cognifide.gradle.aem.api.AemTask
@@ -8,25 +9,22 @@ import com.cognifide.gradle.aem.internal.Patterns
 import com.cognifide.gradle.aem.internal.PropertyParser
 import com.cognifide.gradle.aem.internal.file.FileContentReader
 import com.cognifide.gradle.aem.internal.jsoup.JsoupUtil
-import org.apache.commons.io.FileUtils
+import groovy.lang.Closure
 import org.gradle.api.Project
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DuplicatesStrategy
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.bundling.Zip
-import org.gradle.util.GFileUtils
+import org.gradle.util.ConfigureUtil
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.jsoup.parser.Parser
 import java.io.File
 
 open class ComposeTask : Zip(), AemTask {
-
-    companion object {
-        val NAME = "aemCompose"
-
-        val DEPENDENCIES_SUFFIX = ".dependencies"
-    }
 
     @Nested
     final override val config = AemConfig.of(project)
@@ -58,19 +56,39 @@ open class ComposeTask : Zip(), AemTask {
     @Internal
     private var archiveName: String? = null
 
-    @Input
-    val bundleIncludes = mutableMapOf<String, List<String>>()
-
-    @Internal
-    private val bundleResolvers = mutableMapOf<String, () -> Unit>()
+    @Nested
+    val fileFilterOptions = FileFilterOptions()
 
     @Internal
     var fileFilter: ((CopySpec) -> Unit) = { spec ->
-        spec.exclude(config.filesExcluded)
+        if (fileFilterOptions.excluding) {
+            spec.exclude(config.filesExcluded)
+        }
+
         spec.eachFile({ fileDetail ->
             val path = "/${fileDetail.relativePath.pathString.removePrefix("/")}"
-            if (Patterns.wildcard(path, config.filesExpanded)) {
-                FileContentReader.filter(fileDetail, { propertyParser.expandPackage(it, fileProperties, path) })
+
+            if (fileFilterOptions.expanding) {
+                if (Patterns.wildcard(path, config.filesExpanded)) {
+                    FileContentReader.filter(fileDetail, { propertyParser.expandPackage(it, fileProperties, path) })
+                }
+            }
+
+            if (fileFilterOptions.bundleChecking) {
+                if (Patterns.wildcard(path, "**/install/*.jar")) {
+                    val bundle = fileDetail.file
+                    val isBundle = try {
+                        val manifest = Jar(bundle).manifest.mainAttributes
+                        !manifest.getValue("Bundle-SymbolicName").isNullOrBlank()
+                    } catch (e: Exception) {
+                        false
+                    }
+
+                    if (!isBundle) {
+                        logger.warn("Jar being a part of composed CRX package is not a valid OSGi bundle: $bundle")
+                        fileDetail.exclude()
+                    }
+                }
             }
         })
     }
@@ -175,27 +193,11 @@ open class ComposeTask : Zip(), AemTask {
                 effectiveInstallPath = "$effectiveInstallPath.$runMode"
             }
 
-            val collector = BundleCollector(project)
-            val includes = collector.all
-
-            if (includes.isNotEmpty()) {
-                val resolutionPath = "bundles/${project.path.replace(":", "/").removeSurrounding("/")}"
-                val resolutionDir = AemTask.temporaryDir(this.project, NAME, resolutionPath)
-                val resolver = {
-                    resolutionDir.deleteRecursively()
-                    GFileUtils.mkdirs(resolutionDir)
-
-                    collector.allJars.forEach { FileUtils.copyFileToDirectory(it, resolutionDir) }
-                }
-
-                bundleIncludes[project.name] = includes
-                bundleResolvers[project.name] = resolver
-
-                if (includes.isNotEmpty()) {
-                    into("${PackagePlugin.JCR_ROOT}/$effectiveInstallPath") { spec ->
-                        spec.from(resolutionDir)
-                        fileFilter(spec)
-                    }
+            val bundles = BundleCollector(project).allJars
+            if (bundles.isNotEmpty()) {
+                into("${PackagePlugin.JCR_ROOT}/$effectiveInstallPath") { spec ->
+                    spec.from(bundles)
+                    fileFilter(spec)
                 }
             }
         }
@@ -299,13 +301,23 @@ open class ComposeTask : Zip(), AemTask {
         return extendedArchiveName
     }
 
-    private fun resolveBundles() {
-        bundleResolvers.forEach { it.value() }
+    fun fileFilterOptions(closure: Closure<*>) {
+        ConfigureUtil.configure(closure, fileFilterOptions)
     }
 
-    @TaskAction
-    override fun copy() {
-        resolveBundles()
-        super.copy()
+    class FileFilterOptions {
+
+        var excluding: Boolean = true
+
+        var expanding: Boolean = true
+
+        var bundleChecking: Boolean = true
+
+    }
+
+    companion object {
+        const val NAME = "aemCompose"
+
+        const val DEPENDENCIES_SUFFIX = ".dependencies"
     }
 }

--- a/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/gradle/buildscript.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/gradle/buildscript.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    classpath 'com.cognifide.gradle:aem-plugin:3.0.5'
+    classpath 'com.cognifide.gradle:aem-plugin:3.0.6-SNAPSHOT'
     classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:3.5.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.21"
 }

--- a/src/test/resources/com/cognifide/gradle/aem/test/compose/bundle-and-content/build.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/compose/bundle-and-content/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.cognifide.gradle:aem-plugin:3.0.5'
+        classpath 'com.cognifide.gradle:aem-plugin:3.0.6-SNAPSHOT'
         classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:3.5.0'
     }
 }

--- a/src/test/resources/com/cognifide/gradle/aem/test/debug/build.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/debug/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.cognifide.gradle:aem-plugin:3.0.5'
+        classpath 'com.cognifide.gradle:aem-plugin:3.0.6-SNAPSHOT'
     }
 }
 


### PR DESCRIPTION
since 3.0.0-3.0.5, bundles being compiled could not be a part of CRX package, because Gradle input cache was badly registered in that case.

this PR will fix that and return previous good working behavior
