### PR TITLE
Local instance dir name + multiple types per env

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/Instance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/Instance.kt
@@ -92,10 +92,10 @@ interface Instance : Serializable {
             return instances.filter { instance ->
                 when {
                     config.propParser.flag(AUTHORS_PROP) -> {
-                        Patterns.wildcard(instance.name, "${config.deployEnvironment}-${InstanceType.AUTHOR}")
+                        Patterns.wildcard(instance.name, "${config.deployEnvironment}-${InstanceType.AUTHOR}*")
                     }
                     config.propParser.flag(PUBLISHERS_PROP) -> {
-                        Patterns.wildcard(instance.name, "${config.deployEnvironment}-${InstanceType.PUBLISH}")
+                        Patterns.wildcard(instance.name, "${config.deployEnvironment}-${InstanceType.PUBLISH}*")
                     }
                     else -> Patterns.wildcards(instance.name, instanceFilter)
                 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/InstanceType.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/InstanceType.kt
@@ -12,7 +12,7 @@ enum class InstanceType {
         private val AUTHOR_RULES = listOf("*02")
 
         fun byName(type: String): InstanceType {
-            return values().find { it.name.equals(type, true) }
+            return values().find { it.name.startsWith(type, true) }
                     ?: throw AemException("Invalid instance type: $type")
         }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/LocalHandle.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/LocalHandle.kt
@@ -44,7 +44,7 @@ class LocalHandle(val project: Project, val sync: InstanceSync) {
 
     val config = AemConfig.of(project)
 
-    val dir = File("${config.instancesPath}/${instance.name}")
+    val dir = File("${config.instancesPath}/${instance.typeName}")
 
     val jar = File(dir, "aem-quickstart.jar")
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/LocalInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/LocalInstance.kt
@@ -68,7 +68,7 @@ class LocalInstance(
         get() = ENVIRONMENT
 
     override fun toString(): String {
-        return "LocalInstance(httpUrl='$httpUrl', user='$user', password='$hiddenPassword', type='$typeName', debugPort=$debugPort)"
+        return "LocalInstance(httpUrl='$httpUrl', user='$user', password='$hiddenPassword', typeName='$typeName', debugPort=$debugPort)"
     }
 
     @Transient

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/RemoteInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/RemoteInstance.kt
@@ -38,7 +38,7 @@ class RemoteInstance(
     }
 
     override fun toString(): String {
-        return "RemoteInstance(httpUrl='$httpUrl', user='$user', password='$hiddenPassword', type='$typeName', environment='$environment')"
+        return "RemoteInstance(httpUrl='$httpUrl', user='$user', password='$hiddenPassword', typeName='$typeName', environment='$environment')"
     }
 
     @Transient


### PR DESCRIPTION
* implemented #139 ; instance name will be just `typeName` as is (there will be need to rename directories `local-author` to `author` and `local-publish` to `publish`)
* added possibility to define multiple types of instance for each env, e.g

```
aem {
    config {
        remoteInstance('http://192.168.0.1', 'admin', 'admin', 'author1', 'int')
        remoteInstance('http://192.168.0.2', 'admin', 'admin', 'author2', 'int')
        remoteInstance('http://192.168.0.3', 'admin', 'admin', 'publish1', 'int')
        remoteInstance('http://192.168.0.4', 'admin', 'admin', 'publish2', 'int')
    }
}
```