### PR TITLE
Bundle BND instructions via build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ pluginManagement {
 	resolutionStrategy {
 		eachPlugin {
 			if (requested.id.namespace == 'com.cognifide.aem') {
-				useModule('com.cognifide.gradle:aem-plugin:4.0.7')
+				useModule('com.cognifide.gradle:aem-plugin:4.0.8')
 			}
 		}
 	}
@@ -173,6 +173,9 @@ aem {
         bundlePackageOptions = "-split-package:=merge-first"
         bundleManifestAttributes = true
         bundleBndPath = "${project.file('bnd.bnd')}"
+        bundleBndInstructions = [
+          "-fixupmessages.bundleActivator": "Bundle-Activator * is being imported *;is:=error"
+        ]
     
         if (projectUniqueName) {
             packageName = project.name

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.cognifide.gradle'
-version '4.0.7'
+version '4.0.8'
 description = 'Gradle AEM Plugin'
 defaultTasks = ['clean', 'build', 'publishToMavenLocal']
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/api/AemConfig.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/api/AemConfig.kt
@@ -134,12 +134,28 @@ class AemConfig(
     var bundleManifestAttributes: Boolean = true
 
     /**
-     * Bundle configuration file location consumed by BND tool.
+     * Bundle instructions file location consumed by BND tool.
+     *
+     * If file exists, instructions will be taken from it instead of directly specified
+     * in dedicated property.
      *
      * @see <https://bnd.bndtools.org>
      */
     @Input
     var bundleBndPath: String = "${project.file("bnd.bnd")}"
+
+    /**
+     * Bundle instructions consumed by BND tool (still file has precedence).
+     *
+     * By default, plugin is increasing an importance of some warning so that it will
+     * fail a build instead just log it.
+     *
+     * @see <https://bnd.bndtools.org/chapters/825-instructions-ref.html>
+     */
+    @Input
+    var bundleBndInstructions: MutableMap<String, Any> = mutableMapOf(
+            "-fixupmessages.bundleActivator" to "Bundle-Activator * is being imported *;is:=error"
+    )
 
     /**
      * Automatically determine local package to be uploaded.

--- a/src/main/kotlin/com/cognifide/gradle/aem/api/AemConfig.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/api/AemConfig.kt
@@ -148,7 +148,7 @@ class AemConfig(
      * Bundle instructions consumed by BND tool (still file has precedence).
      *
      * By default, plugin is increasing an importance of some warning so that it will
-     * fail a build instead just log it.
+     * fail a build instead just logging it.
      *
      * @see <https://bnd.bndtools.org/chapters/825-instructions-ref.html>
      */

--- a/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
@@ -120,13 +120,19 @@ class BundlePlugin : Plugin<Project> {
 
         convention.plugins[BND_CONVENTION_PLUGIN] = bundleConvention
 
-        val bndFile = File(AemConfig.of(project).bundleBndPath)
-        if (bndFile.isFile) {
-            bundleConvention.setBndfile(bndFile)
-        }
-
         jar.doLast {
             try {
+                val config = AemConfig.of(project)
+                val instructionFile = File(config.bundleBndPath)
+                if (instructionFile.isFile) {
+                    bundleConvention.setBndfile(instructionFile)
+                }
+
+                val instructions = config.bundleBndInstructions
+                if (instructions.isNotEmpty()) {
+                    bundleConvention.bnd(instructions)
+                }
+
                 bundleConvention.buildBundle()
             } catch (e: Exception) {
                 logger.error("BND tool error: https://bnd.bndtools.org", ExceptionUtils.getRootCause(e))

--- a/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/gradle/buildscript.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/compose/assembly/gradle/buildscript.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    classpath 'com.cognifide.gradle:aem-plugin:4.0.7'
+    classpath 'com.cognifide.gradle:aem-plugin:4.0.8'
     classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:3.5.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.21"
 }

--- a/src/test/resources/com/cognifide/gradle/aem/test/compose/bundle-and-content/settings.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/compose/bundle-and-content/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {
 	resolutionStrategy {
 		eachPlugin {
 			if (requested.id.namespace == 'com.cognifide.aem') {
-				useModule('com.cognifide.gradle:aem-plugin:4.0.7')
+				useModule('com.cognifide.gradle:aem-plugin:4.0.8')
 			}
 		}
 	}

--- a/src/test/resources/com/cognifide/gradle/aem/test/debug/additional/build.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/debug/additional/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.cognifide.gradle:aem-plugin:4.0.7'
+        classpath 'com.cognifide.gradle:aem-plugin:4.0.8'
     }
 }
 

--- a/src/test/resources/com/cognifide/gradle/aem/test/debug/additional/debug.json
+++ b/src/test/resources/com/cognifide/gradle/aem/test/debug/additional/debug.json
@@ -193,6 +193,9 @@
       "bundlePackageOptions": "-split-package:=merge-first",
       "bundleManifestAttributes": true,
       "bundleBndPath": "bnd.bnd",
+      "bundleBndInstructions" : {
+        "-fixupmessages.bundleActivator" : "Bundle-Activator * is being imported *;is:=error"
+      },
 
       "packageName": "additional",
       "packageLocalPath": "",

--- a/src/test/resources/com/cognifide/gradle/aem/test/debug/minimal/build.gradle
+++ b/src/test/resources/com/cognifide/gradle/aem/test/debug/minimal/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-    id 'com.cognifide.aem.base' version '4.0.7'
+    id 'com.cognifide.aem.base' version '4.0.8'
 }

--- a/src/test/resources/com/cognifide/gradle/aem/test/debug/minimal/debug.json
+++ b/src/test/resources/com/cognifide/gradle/aem/test/debug/minimal/debug.json
@@ -52,6 +52,9 @@
       "bundlePackageOptions": "-split-package:=merge-first",
       "bundleManifestAttributes": true,
       "bundleBndPath": "bnd.bnd",
+      "bundleBndInstructions" : {
+        "-fixupmessages.bundleActivator" : "Bundle-Activator * is being imported *;is:=error"
+      },
 
       "packageName": "minimal",
       "packageLocalPath": "",


### PR DESCRIPTION
implementation of #214 ; bnd tool is already doing that as mentioned in issue, but... that root cause of reporting it was just a warning. this improvement is rather demonstrating how to handle warnings and make them build-breakable.