### PR TITLE
Environment hosts conventions

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/environment/Environment.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/environment/Environment.kt
@@ -5,6 +5,7 @@ import com.cognifide.gradle.aem.AemTask
 import com.cognifide.gradle.aem.common.file.FileOperations
 import com.cognifide.gradle.aem.common.file.resolver.FileResolver
 import com.cognifide.gradle.aem.common.utils.Formats
+import com.cognifide.gradle.aem.common.utils.Patterns
 import com.cognifide.gradle.aem.environment.docker.base.CygPath
 import com.cognifide.gradle.aem.environment.docker.base.DockerRuntime
 import com.cognifide.gradle.aem.environment.docker.base.runtime.Toolbox
@@ -226,7 +227,9 @@ class Environment(@JsonIgnore val aem: AemExtension) : Serializable {
     /**
      * Defines hosts to be appended to system specific hosts file.
      */
-    fun hosts(names: Iterable<String>) = hosts.other(names)
+    fun hosts(names: Iterable<String>) = hosts.other(names.map { url ->
+        if (!url.contains("://")) "http://$url" else url // backward compatibility
+    })
 
     /**
      * Configures environment service health checks.

--- a/src/main/kotlin/com/cognifide/gradle/aem/environment/Environment.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/environment/Environment.kt
@@ -84,7 +84,7 @@ class Environment(@JsonIgnore val aem: AemExtension) : Serializable {
     @JsonIgnore
     var healthChecker = HealthChecker(this)
 
-    val hosts = HostOptions()
+    val hosts = HostOptions(this)
 
     val created: Boolean
         get() = rootDir.exists()
@@ -226,7 +226,7 @@ class Environment(@JsonIgnore val aem: AemExtension) : Serializable {
     /**
      * Defines hosts to be appended to system specific hosts file.
      */
-    fun hosts(names: Iterable<String>) = hosts.define(dockerRuntime.hostIp, names)
+    fun hosts(names: Iterable<String>) = hosts.other(names)
 
     /**
      * Configures environment service health checks.

--- a/src/main/kotlin/com/cognifide/gradle/aem/environment/hosts/Host.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/environment/hosts/Host.kt
@@ -16,6 +16,10 @@ class Host(val ip: String, val name: String) : Serializable {
     val text: String
         get() = "$ip\t$name"
 
+    @get:JsonIgnore
+    val httpUrl: String
+        get() = "http://$name"
+
     companion object {
         fun of(value: String): Host {
             val parts = value.trim().split(" ").map { it.trim() }

--- a/src/main/kotlin/com/cognifide/gradle/aem/environment/hosts/Host.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/environment/hosts/Host.kt
@@ -3,32 +3,34 @@ package com.cognifide.gradle.aem.environment.hosts
 import com.cognifide.gradle.aem.environment.EnvironmentException
 import com.fasterxml.jackson.annotation.JsonIgnore
 import java.io.Serializable
+import java.net.URL
 
-class Host(val ip: String, val name: String) : Serializable {
+class Host(val url: String) : Serializable {
+
+    var ip = "127.0.0.1"
+
+    var tags = mutableSetOf<String>()
+
+    @get:JsonIgnore
+    val config = URL(url)
 
     init {
-        if (ip.isBlank() || name.isBlank()) {
-            throw EnvironmentException("Invalid hosts configuration (empty value), ip: $ip, name: $name.")
+        if (url.isBlank()) {
+            throw EnvironmentException("Host URL cannot be blank!")
         }
     }
 
     @get:JsonIgnore
     val text: String
-        get() = "$ip\t$name"
+        get() = "$ip\t${config.host}"
 
-    @get:JsonIgnore
-    val httpUrl: String
-        get() = "http://$name"
-
-    companion object {
-        fun of(value: String): Host {
-            val parts = value.trim().split(" ").map { it.trim() }
-            if (parts.size != 2) {
-                throw EnvironmentException("Invalid hosts value: '$value'")
-            }
-            val (ip, name) = parts
-
-            return Host(ip, name)
-        }
+    fun tag(id: String) {
+        tags.add(id)
     }
+
+    fun tag(ids: Iterable<String>) {
+        tags.addAll(ids)
+    }
+
+    fun tag(vararg ids: String) = tag(ids.asIterable())
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/environment/hosts/HostOptions.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/environment/hosts/HostOptions.kt
@@ -1,26 +1,123 @@
 package com.cognifide.gradle.aem.environment.hosts
 
-class HostOptions {
+import com.cognifide.gradle.aem.environment.Environment
+import com.cognifide.gradle.aem.environment.EnvironmentException
+import net.minidev.json.annotate.JsonIgnore
+import java.io.Serializable
 
-    var defined = mutableListOf<Host>()
+/**
+ * Manages host definitions in case of different purposes.
+ *
+ * Introduces conventions to distinguish hosts in groups:
+ * - 'live' for accessing production site,
+ * - 'demo' for accessing site on which automated tests could be performed,
+ * - 'author' for accessing AEM author instance,
+ * - 'other' for hosts like for AEM dispatcher HTTP server.
+ */
+class HostOptions(environment: Environment) : Serializable {
 
-    fun define(ip: String, name: String) {
-        defined.add(Host(ip, name))
+    var defined = mutableMapOf<String, MutableList<Host>>()
+
+    @get:JsonIgnore
+    val all: List<Host>
+        get() = defined.flatMap { it.value }
+
+    @JsonIgnore
+    var ipDefault = environment.dockerRuntime.hostIp
+
+    fun define(group: String, name: String, ip: String = ipDefault) {
+        defined.getOrPut(group) { mutableListOf() }.add(Host(name, ip))
     }
 
-    fun define(ip: String, vararg names: String) {
-        define(ip, names.asIterable())
+    fun define(group: String, names: Iterable<String>, ip: String = ipDefault) {
+        names.forEach { define(group, it, ip) }
     }
 
-    fun define(ip: String, names: Iterable<String>) {
-        names.forEach { define(ip, it) }
-    }
+    fun host(group: String): Host = group(group).first()
 
-    fun define(vararg values: String) {
-        define(values.asIterable())
-    }
+    fun group(group: String) = defined[group]
+            ?: throw EnvironmentException("Environment has no hosts defined in group '$group'")
 
-    fun define(values: Iterable<String>) {
-        defined.addAll(values.map { Host.of(it) })
+    // ----- DSL shorthands / conventions -----
+
+    /**
+     * Get host responsible for accessing AEM author instance.
+     */
+    @get:JsonIgnore
+    val author: Host
+        get() = host(GROUP_AUTHOR)
+
+    /**
+     * Get hosts responsible for accessing AEM author instances.
+     */
+    @get:JsonIgnore
+    val authors: List<Host>
+        get() = group(GROUP_AUTHOR)
+
+    fun author(name: String) = author(listOf(name))
+
+    fun author(vararg names: String) = author(names.asIterable())
+
+    fun author(names: Iterable<String>) = define(GROUP_AUTHOR, names)
+
+    /**
+     * Get host responsible for accessing demo site (e.g used for automated tests)
+     */
+    @get:JsonIgnore
+    val demo: Host
+        get() = host(GROUP_DEMO)
+
+    /**
+     * Get hosts responsible for accessing demo site (e.g content used for automated tests)
+     */
+    @get:JsonIgnore
+    val demos: List<Host>
+        get() = group(GROUP_DEMO)
+
+    fun demo(name: String) = demo(listOf(name))
+
+    fun demo(vararg names: String) = demo(names.asIterable())
+
+    fun demo(names: Iterable<String>) = define(GROUP_DEMO, names)
+
+    /**
+     * Get host responsible for accessing live site (production content).
+     */
+    @get:JsonIgnore
+    val live: Host
+        get() = host(GROUP_LIVE)
+
+    /**
+     * Get hosts responsible for accessing live site (production content).
+     */
+    @get:JsonIgnore
+    val lives: List<Host>
+        get() = group(GROUP_LIVE)
+
+    fun live(name: String) = live(listOf(name))
+
+    fun live(vararg names: String) = live(names.asIterable())
+
+    fun live(names: Iterable<String>) = define(GROUP_LIVE, names)
+
+    @get:JsonIgnore
+    val others: List<Host>
+        get() = group(GROUP_OTHER)
+
+    fun other(name: String) = other(listOf(name))
+
+    fun other(vararg names: String) = other(names.asIterable())
+
+    fun other(names: Iterable<String>) = define(GROUP_OTHER, names)
+
+    companion object {
+
+        val GROUP_AUTHOR = "author"
+
+        val GROUP_DEMO = "demo"
+
+        val GROUP_LIVE = "live"
+
+        val GROUP_OTHER = "other"
     }
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/environment/tasks/EnvironmentHosts.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/environment/tasks/EnvironmentHosts.kt
@@ -12,7 +12,7 @@ open class EnvironmentHosts : AemDefaultTask() {
 
     @TaskAction
     fun appendHosts() {
-        val hosts = Hosts.of(aem.environment.hosts.all)
+        val hosts = Hosts.of(aem.environment.hosts.defined)
         hosts.append()
 
         aem.notifier.notify("Environment hosts", "Appended with success")

--- a/src/main/kotlin/com/cognifide/gradle/aem/environment/tasks/EnvironmentHosts.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/environment/tasks/EnvironmentHosts.kt
@@ -12,7 +12,8 @@ open class EnvironmentHosts : AemDefaultTask() {
 
     @TaskAction
     fun appendHosts() {
-        Hosts.of(aem.environment.hosts.defined).append()
+        val hosts = Hosts.of(aem.environment.hosts.all)
+        hosts.append()
 
         aem.notifier.notify("Environment hosts", "Appended with success")
     }


### PR DESCRIPTION
Motivation of this to be able to easy reuse host names defined in one place
also in custom tasks scripting:

https://github.com/Cognifide/gradle-aem-multi/issues/67
https://github.com/Cognifide/gradle-aem-multi/issues/68

to be able to write: `aem.environment.hosts.live.httpUrl` instead of hardcoding same domain in multiple places

or `aem.environment.hosts.author.httpUrl` etc