### PR TITLE
Local instance pre-install dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
         * [Task instanceResetup](#task-instanceresetup)
         * [Task instanceCreate](#task-instancecreate)
            * [Configuration of AEM instance source (JAR file or backup file)](#configuration-of-aem-instance-source-jar-file-or-backup-file)
+           * [Pre-installed OSGi bundles and CRX packages](#pre-installed-osgi-bundles-and-crx-packages)
            * [Extracted instance files configuration (optional)](#extracted-instance-files-configuration-optional)
         * [Task instanceBackup](#task-instancebackup)
            * [Work with remote instance backups](#work-with-remote-instance-backups)
@@ -1327,6 +1328,25 @@ aem {
 Notice that, default selector assumes that most recent backup will be selected.
 Ordering by file name including timestamp then local backups precedence when backup is available on both local & remote source.
 Still, backup selector could select exact backup by name when property `localInstance.backup.name` is specified.
+
+##### Pre-installed OSGi bundles and CRX packages
+
+Use dedicated section:
+
+```kotlin
+aem {
+    localInstance {
+        install {
+            files {
+                download("http://my-company.com/aem/packages/my-package.zip")
+            }
+        }
+    }
+}
+```
+
+Files section works in a same way as in [instance satisfy task](#task-instancesatisfy).
+For more details see AEM [File Install Provider](https://helpx.adobe.com/experience-manager/6-5/sites/deploying/using/custom-standalone-install.html#AddingaFileInstallProvider) documentation.
 
 ##### Extracted instance files configuration (optional)
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstance.kt
@@ -149,10 +149,13 @@ class LocalInstance private constructor(aem: AemExtension) : AbstractInstance(ae
         aem.logger.info("Copying quickstart license '$license' to directory '$quickstartDir'")
         manager.quickstart.license?.let { FileUtils.copyFile(it, license) }
 
-        GFileUtils.mkdirs(installDir)
-        aem.logger.info("Copying quickstart install files (pre-installed bundles and packages)" +
-                " to directory '$quickstartDir': ${manager.install.files.joinToString("\n")}")
-        manager.install.files.forEach { FileUtils.copyFileToDirectory(it, installDir) }
+        val installFiles = manager.install.files
+        if (installFiles.isNotEmpty()) {
+            GFileUtils.mkdirs(installDir)
+            aem.logger.info("Copying quickstart install files (pre-installed bundles and packages)" +
+                    " to directory '$quickstartDir': ${installFiles.joinToString("\n")}")
+            installFiles.forEach { FileUtils.copyFileToDirectory(it, installDir) }
+        }
     }
 
     private fun validateFiles() {

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstance.kt
@@ -105,6 +105,10 @@ class LocalInstance private constructor(aem: AemExtension) : AbstractInstance(ae
     val initialized: Boolean
         get() = locked(LOCK_INIT)
 
+    @get:JsonIgnore
+    val installDir: File
+        get() = File(quickstartDir, "install")
+
     private fun binScript(name: String, os: OperatingSystem = OperatingSystem.current()): Script {
         return if (os.isWindows) {
             Script(this, listOf("cmd", "/C"), File(dir, "$name.bat"), File(quickstartDir, "bin/$name.bat"))
@@ -141,6 +145,10 @@ class LocalInstance private constructor(aem: AemExtension) : AbstractInstance(ae
 
         manager.quickstart.license?.let { FileUtils.copyFile(it, license) }
         manager.quickstart.jar?.let { FileUtils.copyFile(it, jar) }
+
+        GFileUtils.mkdirs(installDir)
+
+        manager.install.files.forEach { FileUtils.copyFileToDirectory(it, installDir) }
     }
 
     private fun validateFiles() {

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstance.kt
@@ -143,11 +143,15 @@ class LocalInstance private constructor(aem: AemExtension) : AbstractInstance(ae
     private fun copyFiles() {
         GFileUtils.mkdirs(dir)
 
-        manager.quickstart.license?.let { FileUtils.copyFile(it, license) }
+        aem.logger.info("Copying quickstart JAR '$jar' to directory '$quickstartDir'")
         manager.quickstart.jar?.let { FileUtils.copyFile(it, jar) }
 
-        GFileUtils.mkdirs(installDir)
+        aem.logger.info("Copying quickstart license '$license' to directory '$quickstartDir'")
+        manager.quickstart.license?.let { FileUtils.copyFile(it, license) }
 
+        GFileUtils.mkdirs(installDir)
+        aem.logger.info("Copying quickstart install files (pre-installed bundles and packages)" +
+                " to directory '$quickstartDir': ${manager.install.files.joinToString("\n")}")
         manager.install.files.forEach { FileUtils.copyFileToDirectory(it, installDir) }
     }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstanceManager.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstanceManager.kt
@@ -3,14 +3,15 @@ package com.cognifide.gradle.aem.common.instance
 import com.cognifide.gradle.aem.AemExtension
 import com.cognifide.gradle.aem.common.file.FileOperations
 import com.cognifide.gradle.aem.common.instance.local.BackupResolver
+import com.cognifide.gradle.aem.common.instance.local.InstallResolver
 import com.cognifide.gradle.aem.common.instance.local.QuickstartResolver
 import com.cognifide.gradle.aem.common.instance.local.Source
 import com.cognifide.gradle.aem.common.utils.onEachApply
 import com.fasterxml.jackson.annotation.JsonIgnore
+import org.gradle.util.GFileUtils
 import java.io.File
 import java.io.Serializable
 import java.util.concurrent.TimeUnit
-import org.gradle.util.GFileUtils
 
 class LocalInstanceManager(private val aem: AemExtension) : Serializable {
 
@@ -86,6 +87,15 @@ class LocalInstanceManager(private val aem: AemExtension) : Serializable {
                 else -> null
             }
         }
+
+    val install = InstallResolver(aem)
+
+    /**
+     * Configure CRX packages, bundles to be pre-installed on instance(s).
+     */
+    fun install(options: InstallResolver.() -> Unit) {
+        install.apply(options)
+    }
 
     @Suppress("ComplexMethod")
     fun create(instances: List<LocalInstance>) {

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/InstallResolver.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/InstallResolver.kt
@@ -1,0 +1,24 @@
+package com.cognifide.gradle.aem.common.instance.local
+
+import com.cognifide.gradle.aem.AemExtension
+import com.cognifide.gradle.aem.AemTask
+import com.cognifide.gradle.aem.common.file.resolver.FileResolver
+import com.fasterxml.jackson.annotation.JsonIgnore
+import java.io.File
+
+class InstallResolver(private val aem: AemExtension) {
+
+    var downloadDir = aem.props.string("localInstance.install.downloadDir")?.let { aem.project.file(it) }
+            ?: AemTask.temporaryDir(aem.project, "install")
+
+    private val fileResolver = FileResolver(aem, downloadDir)
+
+    fun files(configurer: FileResolver.() -> Unit) {
+        fileResolver.apply(configurer)
+    }
+
+    @get:JsonIgnore
+    val files: List<File>
+        get() = fileResolver.allFiles
+
+}

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/InstallResolver.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/InstallResolver.kt
@@ -9,7 +9,7 @@ import java.io.File
 class InstallResolver(private val aem: AemExtension) {
 
     var downloadDir = aem.props.string("localInstance.install.downloadDir")?.let { aem.project.file(it) }
-            ?: AemTask.temporaryDir(aem.project, "install")
+            ?: AemTask.temporaryDir(aem.project, "instance/install")
 
     private val fileResolver = FileResolver(aem, downloadDir)
 
@@ -20,5 +20,4 @@ class InstallResolver(private val aem: AemExtension) {
     @get:JsonIgnore
     val files: List<File>
         get() = fileResolver.allFiles
-
 }

--- a/src/test/kotlin/com/cognifide/gradle/aem/test/DebugTest.kt
+++ b/src/test/kotlin/com/cognifide/gradle/aem/test/DebugTest.kt
@@ -42,6 +42,7 @@ class DebugTest : AemTest() {
                 "aem.localInstanceManager.quickstart.downloadDir" to PathValueMatcher(),
                 "aem.localInstanceManager.backup.remoteDir" to PathValueMatcher(),
                 "aem.localInstanceManager.backup.localDir" to PathValueMatcher(),
+                "aem.localInstanceManager.install.downloadDir" to PathValueMatcher(),
                 "aem.packageOptions.contentDir" to PathValueMatcher(),
                 "aem.packageOptions.metaCommonDir" to PathValueMatcher(),
                 "aem.tasks.bundles[*].bndPath" to PathValueMatcher(),

--- a/src/test/resources/com/cognifide/gradle/aem/test/debug/additional/debug.json
+++ b/src/test/resources/com/cognifide/gradle/aem/test/debug/additional/debug.json
@@ -311,6 +311,9 @@
         "remoteDir": "*/additional/build/aem/instanceBackup/remote",
         "localDir": "*/additional/build/aem/instanceBackup/local",
         "suffix": ".backup.zip"
+      },
+      "install": {
+        "downloadDir": "*/additional/build/aem/instance/install"
       }
     },
     "environment" : {

--- a/src/test/resources/com/cognifide/gradle/aem/test/debug/minimal/debug.json
+++ b/src/test/resources/com/cognifide/gradle/aem/test/debug/minimal/debug.json
@@ -148,6 +148,9 @@
         "remoteDir": "*/minimal/build/aem/instanceBackup/remote",
         "localDir": "*/minimal/build/aem/instanceBackup/local",
         "suffix": ".backup.zip"
+      },
+      "install": {
+        "downloadDir": "*/minimal/build/aem/instance/install"
       }
     },
     "environment" : {


### PR DESCRIPTION
impl of #431 

usage

instead of 

```kotlin
aem {
    tasks {
        instanceSatisfy {
            packages {
                download("http://my-company.com/aem/packages/my-package.zip")
            }
        }
    }
}
```

will be possible:

```kotlin
aem {
    localInstance {
        install {
            files {
                download("http://my-company.com/aem/packages/my-package.zip")
            }
        }
    }
}
```