### PR TITLE
#512 automatically creating incidentFilter file - this way developer …

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/tail/InstanceTailer.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/tail/InstanceTailer.kt
@@ -68,11 +68,10 @@ class InstanceTailer(val aem: AemExtension) {
      *
      * Changes in that file are automatically considered (tailer restart is not required).
      */
-    var incidentFilter: File = (
+    var incidentFilter: File =
             aem.props.string("instance.tail.incidentFilter")
                     ?.let { aem.project.file(it) }
                     ?: File(aem.configCommonDir, "instanceTail/incidentFilter.txt")
-            ).apply { parentFile.mkdirs(); createNewFile() }
 
     /**
      * Time window in which exceptions will be aggregated and reported as single incident.
@@ -110,6 +109,7 @@ class InstanceTailer(val aem: AemExtension) {
 
     fun tail() {
         checkStartLock()
+        initIncidentFilter()
 
         runBlocking {
             startAll().forEach { tailer ->
@@ -129,6 +129,11 @@ class InstanceTailer(val aem: AemExtension) {
             throw InstanceTailerException("Another instance of log tailer is running for this project.")
         }
         logFiles.lock()
+    }
+
+    private fun initIncidentFilter() = incidentFilter.run {
+        parentFile.mkdirs()
+        createNewFile()
     }
 
     private fun startAll(): List<LogTailer> {

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/tail/InstanceTailer.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/tail/InstanceTailer.kt
@@ -68,8 +68,11 @@ class InstanceTailer(val aem: AemExtension) {
      *
      * Changes in that file are automatically considered (tailer restart is not required).
      */
-    var incidentFilter: File = aem.props.string("instance.tail.incidentFilter")?.let { aem.project.file(it) }
-            ?: File(aem.configCommonDir, "instanceTail/incidentFilter.txt")
+    var incidentFilter: File = (
+            aem.props.string("instance.tail.incidentFilter")
+                    ?.let { aem.project.file(it) }
+                    ?: File(aem.configCommonDir, "instanceTail/incidentFilter.txt")
+            ).apply { parentFile.mkdirs(); createNewFile() }
 
     /**
      * Time window in which exceptions will be aggregated and reported as single incident.

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/tail/io/UrlSource.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/tail/io/UrlSource.kt
@@ -28,13 +28,13 @@ class UrlSource(
         try {
             val chunk = parser()
             if (!wasStable) {
-                logger.info("Tailing resumed for $instance")
+                logger.lifecycle("Tailing resumed for $instance")
                 wasStable = true
             }
             chunk
         } catch (ex: RequestException) {
             if (wasStable) {
-                logger.warn("Tailing paused for $instance due to '${ex.message}'. Waiting for resuming.")
+                logger.warn("Tailing paused for $instance due to '${ex.message}'. Awaiting resumption.")
             }
             wasStable = false
             emptyList<T>()


### PR DESCRIPTION
…can simply start adding filtering rules without the need to restart instanceTail