### PR TITLE
RCP regression fixes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1676,7 +1676,7 @@ Execute any JCR File Vault command.
 For instance, to reflect `instanceRcp` functionality, command below could be executed:
 
 ```bash
-gradlew :site.demo:packageSync -Ppackage.vlt.command='rcp -b 100 -r -u -n http://admin:admin@localhost:4502/crx/-/jcr:root/content/dam/example http://admin:admin@localhost:4503/crx/-/jcr:root/content/dam/example' 
+gradlew :site.demo:packageVlt -Ppackage.vlt.command='rcp -b 100 -r -u -n http://admin:admin@localhost:4502/crx/-/jcr:root/content/dam/example http://admin:admin@localhost:4503/crx/-/jcr:root/content/dam/example' 
 ```
 
 For more details about available parameters, please visit [VLT Tool documentation](https://helpx.adobe.com/experience-manager/6-4/sites/developing/using/ht-vlttool.html).
@@ -2368,20 +2368,20 @@ Copy JCR content from one instance to another. Sample usages below.
 * Using predefined instances with multiple different source and target nodes:
 
   ```bash
-  gradlew :instanceRcp -Prcp.source.instance=int-author -Prcp.target.instance=local-author -Prcp.paths=[/content/example-demo=/content/example,/content/dam/example-demo=/content/dam/example]
+  gradlew :instanceRcp -Pinstance.rcp.source=int-author -Pinstance.rcp.target=local-author -Pinstance.rcp.paths=[/content/example-demo=/content/example,/content/dam/example-demo=/content/dam/example]
   ```
 
 * Using predefined instances with multiple same source and target nodes:
 
   ```bash
-  gradlew :rcp -Prcp.source.instance=stg-author -Prcp.target.instance=int-author -Prcp.paths=[/content/example,/content/example2]
+  gradlew :instanceRcp -Prcp.source.instance=stg-author -Pinstance.rcp.target.instance=int-author -Pinstance.rcp.paths=[/content/example,/content/example2]
   ```
   Right side of assignment could skipped if equals to left (same path on both source & target instance).
 
 * Using predefined instances with source and target nodes specified in file:
 
   ```bash
-  gradlew :rcp -Prcp.source.instance=int-author -Prcp.target.instance=local-author -Prcp.pathsFile=paths.txt
+  gradlew :instanceRcp -Pinstance.rcp.source=int-author -Pinstance.rcp.target=local-author -Pinstance.rcp.pathsFile=paths.txt
   ```
 
   File format:
@@ -2397,14 +2397,13 @@ Copy JCR content from one instance to another. Sample usages below.
 * Using dynamically defined instances:
 
   ```bash
-  gradlew :rcp -Prcp.source.instance=http://user:pass@192.168.66.66:4502 -Prcp.target.instance=http://user:pass@192.168.33.33:4502 -Prcp.paths=[/content/example-demo=/content/example]
+  gradlew :instanceRcp -Pinstance.rcp.source=http://user:pass@192.168.66.66:4502 -Pinstance.rcp.target=http://user:pass@192.168.33.33:4502 -Pinstance.rcp.paths=[/content/example-demo=/content/example]
   ```
 
 Keep in mind, that copying JCR content between instances, could be a trigger for running AEM workflows like *DAM Update Asset* which could cause heavy load on instance.
 Consider disabling AEM workflow launchers before running this task and re-enabling after.
 
 RCP task is internally using [Vault Remote Copy](http://jackrabbit.apache.org/filevault/rcp.html) which requires bundle *Apache Sling Simple WebDAV Access to repositories (org.apache.sling.jcr.webdav)* present in active state on instance.
-
 
 #### Task `instanceGroovyEval`
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("commons-validator:commons-validator:1.6")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.10.1")
     implementation("org.reflections:reflections:0.9.9")
-    implementation("org.apache.jackrabbit.vault:vault-cli:3.2.4")
+    implementation("org.apache.jackrabbit.vault:vault-cli:3.4.0")
     implementation("org.jsoup:jsoup:1.12.1")
     implementation("org.samba.jcifs:jcifs:1.3.18-kohsuke-1")
     implementation("biz.aQute.bnd:biz.aQute.bnd.gradle:4.2.0")

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/rcp/InstanceRcp.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/rcp/InstanceRcp.kt
@@ -21,6 +21,7 @@ open class InstanceRcp : AemDefaultTask() {
         aem.prop.string("instance.rcp.target")?.run { targetInstance = aem.instance(this) }
         aem.prop.list("instance.rcp.paths")?.let { paths = it }
         aem.prop.string("instance.rcp.pathsFile")?.let { pathsFile = aem.project.file(it) }
+        aem.prop.string("instance.rcp.workspace")?.let { workspace = it }
         aem.prop.string("instance.rcp.opts")?.let { opts = it }
 
         options()

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/rcp/RcpClient.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/rcp/RcpClient.kt
@@ -17,6 +17,8 @@ class RcpClient(private val aem: AemExtension) {
 
     var pathsFile: File? = null
 
+    var workspace = "crx"
+
     var opts: String = "-b 100 -r -u"
 
     val stopWatch = StopWatch()
@@ -51,9 +53,10 @@ class RcpClient(private val aem: AemExtension) {
     fun copy(sourcePath: String, targetPath: String) {
         checkInstances()
         stopWatch.apply { if (!isStarted) start() else resume() }
-        aem.vlt("rcp $opts ${sourceInstance!!.httpBasicAuthUrl}/crx/-/jcr:root$sourcePath ${targetInstance!!.httpBasicAuthUrl}/crx/-/jcr:root$targetPath")
+        aem.vlt("rcp $opts ${sourceInstance!!.httpBasicAuthUrl}/$workspace/-/jcr:root$sourcePath " +
+                "${targetInstance!!.httpBasicAuthUrl}/$workspace/-/jcr:root$targetPath")
         copiedPaths++
-        stopWatch.stop()
+        stopWatch.suspend()
     }
 
     fun summary(): RcpSummary {


### PR DESCRIPTION
updated vault-cli because the previous one seems that it is not working on AEM 6.4/6.5 in all cases.

https://www.apache.org/dist/jackrabbit/filevault/3.4.0/RELEASE-NOTES.txt

> Bug fixes:
    * [JCRVLT-323] - Unable to perform sync due to wrong default workspace handling

