### PR TITLE
Repository node upload and download files

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/repository/Repository.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/repository/Repository.kt
@@ -33,6 +33,15 @@ class Repository(sync: InstanceSync) : InstanceService(sync) {
     }
 
     /**
+     * When trying to upload file under '/content/dam', repository will use for upload dedicated AEM service
+     * instead of using Sling service.
+     */
+    val damUploads = aem.obj.boolean {
+        convention(true)
+        aem.prop.boolean("instance.repository.damUploads")?.let { set(it) }
+    }
+
+    /**
      * Manipulate node at given path (CRUD).
      */
     fun node(path: String): Node = Node(this, path)


### PR DESCRIPTION
node uploads is intelligent. when path is located under /content/dam then separate / dedicated DAM endpoint is used (which also is processing metadata and renditions) instead of default Sling one


```kotlin
aem {
    tasks {
        register("saveFile") {
            doLast {
                authorInstance.sync {
                    val source = repository.node("/content/dam/we-retail/en/features/cart.png")
                    val image = source.download()

                    logger.lifecycle("Downloaded image: $image")

                    val target = source.parent.child("${source.baseName}2.${source.extension}")

                    target.upload(image)

                    logger.lifecycle("Uploaded image to: $target")
                }
            }
        }
    }
}
```