### PR TITLE
Resolving bundles and packages from urls while composing package

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ repositories {
 dependencies {
     implementation(gradleApi())
 
-    implementation("com.cognifide.gradle:common-plugin:0.1.26")
+    implementation("com.cognifide.gradle:common-plugin:0.1.27")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.10.1")
     implementation("com.jayway.jsonpath:json-path:2.4.0")
@@ -119,11 +119,11 @@ tasks {
     }
 
     named<Task>("build") {
-        dependsOn("sourcesJar"/*, "javadocJar"*/) // TODO fix dokka
+        dependsOn("sourcesJar", "javadocJar")
     }
 
     named<Task>("publishToMavenLocal") {
-        dependsOn("sourcesJar"/*, "javadocJar"*/) // TODO fix dokka
+        dependsOn("sourcesJar", "javadocJar")
     }
 
     named<ProcessResources>("processResources") {
@@ -166,7 +166,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             from(components["java"])
             artifact(tasks["sourcesJar"])
-            /*artifact(tasks["javadocJar"]) TODO fix dokka */
+            artifact(tasks["javadocJar"])
         }
     }
 }
@@ -246,7 +246,7 @@ githubRelease {
     token((project.findProperty("github.token") ?: "").toString())
     tagName(project.version.toString())
     releaseName(project.version.toString())
-    releaseAssets(tasks["jar"], tasks["sourcesJar"]/*, tasks["javadocJar"] TODO fix dokka */)
+    releaseAssets(tasks["jar"], tasks["sourcesJar"], tasks["javadocJar"])
     draft((project.findProperty("github.draft") ?: "false").toString().toBoolean())
     prerelease((project.findProperty("github.prerelease") ?: "false").toString().toBoolean())
     overwrite((project.findProperty("github.override") ?: "true").toString().toBoolean())

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=11.0.9
 release.useAutomaticVersion=true
-org.gradle.jvmargs=-Xmx512m
+org.gradle.jvmargs=-Xmx1024m

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
@@ -206,6 +206,7 @@ class PackagePluginTest : AemBuildTest() {
                         
                         nestPackage("com.adobe.cq:core.wcm.components.all:2.8.0")
                         nestPackage("com.adobe.cq:core.wcm.components.examples:2.8.0")
+                        nestPackage("https://github.com/icfnext/aem-groovy-console/releases/download/14.0.0/aem-groovy-console-14.0.0.zip")
                     }
                 }
                 """)
@@ -225,6 +226,7 @@ class PackagePluginTest : AemBuildTest() {
             assertZipEntry(pkg, "jcr_root/apps/package-nesting-repository/install.author/search-webconsole-plugin-1.3.0.jar")
             assertZipEntry(pkg, "jcr_root/etc/packages/adobe/cq60/core.wcm.components.all-2.8.0.zip")
             assertZipEntry(pkg, "jcr_root/etc/packages/adobe/cq60/core.wcm.components.examples-2.8.0.zip")
+            assertZipEntry(pkg, "jcr_root/etc/packages/ICF Next/aem-groovy-console-14.0.0.zip")
 
             assertZipEntryEquals(pkg, "META-INF/vault/filter.xml", """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -234,6 +236,7 @@ class PackagePluginTest : AemBuildTest() {
                   <filter root="/apps/package-nesting-repository/install.author/search-webconsole-plugin-1.3.0.jar"/>
                   <filter root="/etc/packages/adobe/cq60/core.wcm.components.all-2.8.0.zip"/>
                   <filter root="/etc/packages/adobe/cq60/core.wcm.components.examples-2.8.0.zip"/>
+                  <filter root="/etc/packages/ICF Next/aem-groovy-console-14.0.0.zip"/>
                   
                 </workspaceFilter>
             """)

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/compose/BundleInstalledResolved.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/compose/BundleInstalledResolved.kt
@@ -1,22 +1,19 @@
 package com.cognifide.gradle.aem.pkg.tasks.compose
 
 import com.cognifide.gradle.aem.pkg.tasks.PackageCompose
-import com.cognifide.gradle.common.build.DependencyFile
 import org.gradle.api.tasks.Input
 
 class BundleInstalledResolved(private val target: PackageCompose, @Input val notation: Any) : BundleInstalled {
 
     private val aem = target.aem
 
-    private val project = aem.project
+    private val resolvedFile by lazy { aem.common.resolveFile(notation) }
 
-    private val dependencyFile = DependencyFile(project, notation)
-
-    override val file = aem.obj.file { fileProvider(aem.obj.provider { dependencyFile.file }) }
+    override val file = aem.obj.file { fileProvider(aem.obj.provider { resolvedFile }) }
 
     override val dirPath = aem.obj.string { convention(target.bundlePath) }
 
-    override val fileName = aem.obj.string { convention(aem.obj.provider { dependencyFile.file.name }) }
+    override val fileName = aem.obj.string { convention(aem.obj.provider { resolvedFile.name }) }
 
     override val vaultFilter = aem.obj.boolean { convention(target.vaultFilters) }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/compose/PackageNestedResolved.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/compose/PackageNestedResolved.kt
@@ -9,15 +9,13 @@ class PackageNestedResolved(private val target: PackageCompose, @Input val notat
 
     private val aem = target.aem
 
-    private val project = aem.project
+    private val resolvedFile by lazy { aem.common.resolveFile(DependencyFile.hintNotation(notation, "zip")) }
 
-    private val dependencyFile = DependencyFile(project, DependencyFile.hintNotation(notation, "zip"))
+    override val file = aem.obj.file { fileProvider(aem.obj.provider { resolvedFile }) }
 
-    override val file = aem.obj.file { fileProvider(aem.obj.provider { dependencyFile.file }) }
+    override val dirPath = aem.obj.string { convention(target.nestedPath.map { "$it/${PackageFile(resolvedFile).group}" }) }
 
-    override val dirPath = aem.obj.string { convention(target.nestedPath.map { "$it/${PackageFile(dependencyFile.file).group}" }) }
-
-    override val fileName = aem.obj.string { convention(aem.obj.provider { dependencyFile.file.name }) }
+    override val fileName = aem.obj.string { convention(aem.obj.provider { resolvedFile.name }) }
 
     override val vaultFilter = aem.obj.boolean { convention(target.vaultFilters) }
 }


### PR DESCRIPTION
```kotlin
aem {
        tasks {
            packageCompose {
                installBundle("com.neva.felix:search-webconsole-plugin:1.3.0")
                installBundle("https://dl.bintray.com/neva-dev/maven-public/com/neva/felix/search-webconsole-plugin/1.3.0/:search-webconsole-plugin-1.3.0.jar") // new one! - alternatively
                        
                nestPackage("com.adobe.cq:core.wcm.components.all:2.8.0")
                nestPackage("https://github.com/icfnext/aem-groovy-console/releases/download/14.0.0/aem-groovy-console-14.0.0.zip") // new one!
// ...                  
```