### PR TITLE
Package validate task extracted

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ repositories {
 dependencies {
     implementation(gradleApi())
 
-    implementation("com.cognifide.gradle:common-plugin:0.1.28")
+    implementation("com.cognifide.gradle:common-plugin:0.1.30")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.10.1")
     implementation("com.jayway.jsonpath:json-path:2.4.0")

--- a/docs/local-instance-plugin.md
+++ b/docs/local-instance-plugin.md
@@ -137,17 +137,18 @@ This behavior could be customized by `localInstance` section of plugin DSL:
 ```kotlin
 aem {
     localInstance {
-        rootDir = file(".instance") // path under which local instance files are stored
-        overridesDir = file("gradle/instance/local") // path with directories instance specific (common, author, publish) holding files that can override default instance files
-        expandProperties = mapOf() // place where additional properties can be defined
-        expandFiles = listOf( // file patterns which allows using variables inside
+        rootDir.set(file(".instance")) // path under which local instance files are stored
+        configDir.set(file("src/aem/localInstance"))
+        overrideDir.set(configDir.dir("override")) // path with directories instance specific (common, author, publish) holding files that can override default instance files
+        expandProperties.set(mapOf<String, Any>()) // place where additional properties can be defined
+        expandFiles.set(listOf( // file patterns which allows using variables inside
             "**/*.properties", 
             "**/*.sh", 
             "**/*.bat", 
             "**/*.xml",
             "**/start",
             "**/stop"
-        ) 
+        ))
     }
 }
 ```
@@ -167,17 +168,17 @@ It is needed to override only two properties in the final `sling.properties` fil
 * and `org.osgi.framework.bootdelegation`
   * to solve known [FELIX-6184](https://issues.apache.org/jira/browse/FELIX-6184) issue 
 
-To achieve that, add file with your props under `gradle` directory in your project:
-`gradle/instance/local/common/crx-quickstart/conf/sling.properties` 
+To achieve that, add file with your props under `src/aem/localInstance` directory in your project:
+`src/aem/localInstance/common/crx-quickstart/conf/sling.properties` 
 
 ```properties
 org.osgi.framework.system.packages.extra=org.apache.sling.launchpad.api;version\=1.2.0 ${org.apache.sling.launcher.system.packages},com.sun.org.apache.xpath.internal;version\="{dollar}{felix.detect.java.version}",com.sun.activation.registries;version\="{dollar}{felix.detect.java.version}"
 org.osgi.framework.bootdelegation=sun.*,com.sun.*,jdk.internal.reflect,jdk.internal.reflect.*
 ```
 
-Now, when creating a new instance with this configuration, only those two properties will get overridden in `slin.properties`.
+Now, when creating a new instance with this configuration, only those two properties will get overridden in `sling.properties`.
 
-Notice, that adding the file under `gradle/instance/local/common` will apply it both for author and publish instances.
+Notice that adding the file under `src/aem/localInstance/common` will apply it both for author and publish instances.
 
 ## Task `instanceBackup`
 
@@ -194,7 +195,7 @@ Most often it will be path: *build/aem/instanceBackup/local/xxx.backup.zip*. It 
 aem {
     localInstance {
         backup {
-            localDir = file("any/other/directory")
+            localDir.set(file("any/other/directory"))
         }
     }
 }

--- a/docs/package-plugin.md
+++ b/docs/package-plugin.md
@@ -16,6 +16,7 @@
      * [Assembling packages (merging all-in-one)](#assembling-packages-merging-all-in-one)
      * [Expandable properties](#expandable-properties)
   * [Task packagePrepare](#task-packageprepare)
+  * [Task packageValidate](#task-packagevalidate)
   * [Task packageDeploy](#task-packagedeploy)
      * [Deploying only to desired instances](#deploying-only-to-desired-instances)
      * [Deploying options](#deploying-options)
@@ -71,14 +72,6 @@ aem {
                 ))
                 name.set(archiveBaseName)
                 group.set(project.grouop)
-            }
-            validator {
-                enabled.set(true)
-                verbose.set(true)
-                severity("MAJOR")
-                planName.set("plan.json")
-                jcrPrivileges.set(listOf("crx:replicate"))
-                cndFiles.from(packageOptions.configDir.file("nodetypes.cnd"))
             }
             fileFilter {
                 expanding = true
@@ -342,9 +335,34 @@ Processes CRX package metadata - combines default files provided by plugin itsel
 Also responsible for synchronizing Vault node types consumed later by [CRX package validation](#crx-package-validation) in the end of [compose task](#task-packagecompose).
 Covers extracted logic being initially a part of compose task. Reason of separation is effectively better Gradle caching.
  
+## Task `packageValidate`
+
+Validates composed CRX package.
+
+For setting common options see section [CRX package validation](#crx-package-validation). 
+
+For setting project/package specific options use snippet below:
+
+```kotlin
+tasks {
+    packageValidate {
+        validator {
+            enabled.set(true)
+            verbose.set(true)
+            severity("MAJOR")
+            planName.set("plan.json")
+            jcrPrivileges.set(listOf("crx:replicate"))
+            cndFiles.from(packageOptions.configDir.file("nodetypes.cnd"))
+        }
+    }
+}
+```
+ 
 ## Task `packageDeploy` 
 
-Upload & install CRX package into AEM instance(s). Primary, recommended form of deployment. Optimized version of `packageUpload packageInstall`.
+Upload & install CRX package into AEM instance(s). 
+
+Recommended form of deployment. Optimized version of `packageUpload packageInstall`.
 
 ### Deploying only to desired instances
 

--- a/docs/package-plugin.md
+++ b/docs/package-plugin.md
@@ -110,21 +110,19 @@ ZIP file name and metadata (Vault properties) of composed CRX package are set by
 However, only if it is required (adapting the project to fit convention is more recommended approach), following snippet might be useful, to know how to customize particular values:
 
 ```kotlin
-aem {
-    tasks {
-        packageCompose {
-            // Controlling ZIP file name by properties coming from inherited Gradle ZIP task: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Zip.html
-            archiveBaseName.set("my-package")
-    
-            // Controlling values visible in CRX Package Manager
-            vaultDefinition { 
-                properties.set(mapOf(
-                    "acHandling" to "merge_preserve",
-                    "requiresRoot" to false
-                ))
-                name.set(archiveBaseName)
-                group.set(project.group)
-            }
+tasks {
+    packageCompose {
+        // Controlling ZIP file name by properties coming from inherited Gradle ZIP task: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Zip.html
+        archiveBaseName.set("my-package")
+
+        // Controlling values visible in CRX Package Manager
+        vaultDefinition { 
+            properties.set(mapOf(
+                "acHandling" to "merge_preserve",
+                "requiresRoot" to false
+            ))
+            name.set(archiveBaseName)
+            group.set(project.group)
         }
     }
 }
@@ -200,14 +198,22 @@ Package validation report is saved at path relative to project building CRX pack
 
 ### Including additional OSGi bundle into CRX package
 
-Use dedicated task method named `fromJar`, for example:
+Use dedicated task method named `installBundle`, for example:
 
 ```kotlin
-aem {
-    tasks {
-        packageCompose {
-            installBundle("com.github.mickleroy:aem-sass-compiler:1.0.1")
-        }
+tasks {
+    packageCompose {
+        installBundle("com.github.mickleroy:aem-sass-compiler:1.0.1")
+    }
+}
+```
+
+If bundle is build by other project:
+
+```kotlin
+tasks {
+    packageCompose {
+        installBundleProject(":core") // must apply plugin 'com.cognifide.aem.bundle'
     }
 }
 ```
@@ -216,15 +222,23 @@ For reference, see usage above in [AEM Multi-Project Example](https://github.com
 
 ### Nesting CRX packages
 
-Use dedicated task method named `fromZip`, For example:
+Use dedicated task method named `nestPackage`, For example:
 
 ```kotlin
-aem {
-    tasks {
-        packageCompose {
-            nestPackage("com.adobe.cq:core.wcm.components.all:2.4.0")
-            nestPackage("com.adobe.cq:core.wcm.components.examples:2.4.0")
-        }
+tasks {
+    packageCompose {
+        nestPackage("com.adobe.cq:core.wcm.components.all:2.4.0")
+        nestPackage("com.adobe.cq:core.wcm.components.examples:2.4.0")
+    }
+}
+```
+
+If package is build by other project:
+
+```kotlin
+tasks {
+    packageCompose {
+        nestPackageProject(":ui.content") // must apply plugin 'com.cognifide.aem.package'
     }
 }
 ```
@@ -233,13 +247,12 @@ aem {
 
 Let's assume following project structure:
 
-* *aem/build.gradle.kts* (project `:aem`, no source files at all)
-* *aem/common/build.gradle.kts*  (project `:aem:common`, JCR content and OSGi bundle)
-* *aem/sites/build.gradle.kts*  (project `:aem:sites`, JCR content and OSGi bundle)
-* *aem/site.live/build.gradle.kts*  (project `:aem:site.live`, JCR content only)
-* *aem/site.demo/build.gradle.kts*  (project `:aem:site.demo`, JCR content only)
+* *build.gradle.kts* (project `:`, no source files at all)
+* *core/build.gradle.kts*  (project `:core`, OSGi bundle only)
+* *ui.apps/build.gradle.kts*  (project `:ui.apps`, JCR content only)
+* *ui.content/build.gradle.kts*  (project `:ui.content`, JCR content only)
 
-File content of *aem/build.gradle.kts*:
+File content of *build.gradle.kts*:
 
 ```kotlin
 plugins {
@@ -249,28 +262,34 @@ plugins {
 aem {
     tasks {
         packageCompose {
-            mergePackageProject(":aem:common")
-            mergePackageProject(":aem:sites")
-            mergePackageProject(":aem:site.live")
-            mergePackageProject(":aem:site.demo")
+            installBundleProject(":core")
+            mergePackageProject(":ui.apps")
+            mergePackageProject(":ui.content")
         }
     }    
 }
 ```
 
-When building via command `gradlew :aem:build`, then the effect will be a CRX package with assembled JCR content and OSGi bundles from projects: `:aem:sites`, `:aem:common`, `:aem:site.live`, `:aem:site.demo`.
+When building via command `gradlew :build`, then the effect will be a CRX package with merged JCR content from projects `:ui.apps`, `:ui.content` and OSGi bundle built by project `:core`.
+[Vault workspace filters](http://jackrabbit.apache.org/filevault/filter.html) (defined in file _filter.xml_) from `:ui.apps` and `:ui.content` sub-projects will be combined into single one automatically. However, one rule must be kept while developing a multi-module project: **all Vault filter roots of all projects must be exclusive**. In general, they are most often exclusive, to avoid strange JCR installer behaviors, but sometimes exceptional workspace filter rules are being applied like `mode="merge"` etc.
 
-Gradle AEM Plugin is configured in a way that project can have:
+Gradle AEM Plugin is configured in a way that single Gradle project could have:
  
 * JCR content,
 * source code to compile OSGi bundle,
 * both.
 
-By mixing usages of methods `nestPackage*`, `installBundle*` or `mergePackage*` there is ability to create any assembly CRX package with content of any type without restructuring the project.
+It is worth to know a difference when comparing to package built by Maven and [Content Package Maven Plugin](https://helpx.adobe.com/pl/experience-manager/6-4/sites/developing/using/vlt-mavenplugin.html).
+When using it, there is a need for much more modules. Separate one for building OSGi bundle and other one for building CRX package and nesting built OSGi bundle.
+When using Gradle AEM Plugin, there is just much more flexibility.
 
+By mixing usages of methods `nestPackage*`, `installBundle*` or `mergePackage*` there is ability to create any assembly CRX package with content of any type without restructuring the project.
 When using `installBundle` there is an ability to pass lambda to customize options like bundle run mode.
 
-However, one rule must be kept while developing a multi-module project: **all Vault filter roots of all projects must be exclusive**. In general, they are most often exclusive, to avoid strange JCR installer behaviors, but sometimes exceptional [workspace filter](http://jackrabbit.apache.org/filevault/filter.html) rules are being applied like `mode="merge"` etc.
+By default, Gradle AEM Plugin will ensure:
+
+* Running unit tests for all sub-projects providing OSGi bundles to be put under install path inside built assembly package when using method `installBundleProject`. To disable, set property `package.bundleTest=false`.
+* Running package validations for all sub-projects providing CRX package to be nested when using method `nestPackageProject`. To disable it, set property `package.nestedValidation=false`.
 
 ### Expandable properties
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=11.0.12
+version=11.1.0
 release.useAutomaticVersion=true
 org.gradle.jvmargs=-Xmx1024m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=11.0.11
+version=11.0.12
 release.useAutomaticVersion=true
 org.gradle.jvmargs=-Xmx1024m

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/bundle/BundlePluginTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/bundle/BundlePluginTest.kt
@@ -85,6 +85,9 @@ class BundlePluginTest : AemBuildTest() {
                     compileOnly("org.slf4j:slf4j-api:1.5.10")
                     compileOnly("org.osgi:osgi.cmpn:6.0.0")
                     compileOnly("com.adobe.aem:uber-jar:6.5.0:apis")
+                    
+                    testImplementation("org.junit.jupiter:junit-jupiter:5.5.2")
+                    testImplementation("io.wcm:io.wcm.testing.aem-mock.junit5:2.5.2")
                 }
 
                 tasks {

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/instance/local/LocalInstancePluginTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/instance/local/LocalInstancePluginTest.kt
@@ -111,7 +111,7 @@ class LocalInstancePluginTest : AemBuildTest() {
                 
                 repositories {
                     jcenter()
-                    maven { url = uri("https://repo.adobe.com/nexus/content/groups/public") }
+                    maven("https://repo.adobe.com/nexus/content/groups/public")
                 }
                 
                 aem {

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
@@ -273,12 +273,13 @@ class PackagePluginTest : AemBuildTest() {
                 
                 repositories {
                     jcenter()
+                    maven("https://repo.adobe.com/nexus/content/groups/public")
                 }
                 
                 tasks {
                     packageCompose {
-                        nestPackageBuilt(":ui.content:packageCompose")
-                        installBundleBuilt(":ui.apps:bundleCompose")
+                        nestPackageProject(":ui.content")
+                        installBundleProject(":ui.apps")
                     }
                 }
                 """)
@@ -291,6 +292,10 @@ class PackagePluginTest : AemBuildTest() {
 
         runBuild(projectDir, "packageCompose", "-Poffline") {
             assertTask(":packageCompose")
+            assertTask(":ui.apps:bundleCompose")
+            assertTask(":ui.apps:test")
+            assertTask(":ui.content:packageCompose")
+            assertTask(":ui.content:packageValidate")
 
             val pkg = file("build/packageCompose/example-1.0.0.zip")
 
@@ -321,11 +326,15 @@ class PackagePluginTest : AemBuildTest() {
             
             repositories {
                 jcenter()
+                maven("https://repo.adobe.com/nexus/content/groups/public")
             }
             
             dependencies {
                 compileOnly("org.slf4j:slf4j-api:1.5.10")
                 compileOnly("org.osgi:osgi.cmpn:6.0.0")
+                
+                testImplementation("org.junit.jupiter:junit-jupiter:5.5.2")
+                testImplementation("io.wcm:io.wcm.testing.aem-mock.junit5:2.5.2")
             }
             
             tasks {

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
@@ -70,8 +70,9 @@ class PackagePluginTest : AemBuildTest() {
             """)
         }
 
-        runBuild(projectDir, "packageCompose", "-Poffline") {
+        runBuild(projectDir, "packageValidate", "-Poffline") {
             assertTask(":packageCompose", TaskOutcome.UP_TO_DATE)
+            assertTask(":packageValidate")
         }
     }
 
@@ -176,8 +177,9 @@ class PackagePluginTest : AemBuildTest() {
             """)
         }
 
-        runBuild(projectDir, ":assembly:packageCompose", "-Poffline") {
+        runBuild(projectDir, ":assembly:packageValidate", "-Poffline") {
             assertTask(":assembly:packageCompose", TaskOutcome.UP_TO_DATE)
+            assertTask(":assembly:packageValidate")
         }
     }
 
@@ -242,8 +244,9 @@ class PackagePluginTest : AemBuildTest() {
             """)
         }
 
-        runBuild(projectDir, "packageCompose", "-Poffline") {
+        runBuild(projectDir, "packageValidate", "-Poffline") {
             assertTask(":packageCompose", TaskOutcome.UP_TO_DATE)
+            assertTask(":packageValidate")
         }
     }
 

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/test/AemBuildTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/test/AemBuildTest.kt
@@ -39,6 +39,8 @@ open class AemBuildTest {
         build()
     }
 
+    // === Samples  ===
+
     fun File.helloServiceJava(rootPath: String = "") {
         file(rootPath(rootPath, "src/main/java/com/company/example/aem/HelloService.java"), """
             package com.company.example.aem;
@@ -62,6 +64,29 @@ open class AemBuildTest {
                 @Deactivate
                 protected void deactivate() {
                     LOG.info("Good bye world!");
+                }
+            }
+        """)
+
+        file(rootPath(rootPath, "src/test/java/com/company/example/aem/HelloServiceTest.java"), """
+            package com.company.example.aem;
+            
+            import static org.junit.jupiter.api.Assertions.*;
+            
+            import org.junit.jupiter.api.Test;
+            import org.junit.jupiter.api.extension.ExtendWith;
+            import io.wcm.testing.mock.aem.junit5.AemContext;
+            import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+            
+            @ExtendWith(AemContextExtension.class)
+            class HelloServiceTest {
+                
+                private final AemContext context = new AemContext();
+                    
+                @Test
+                void shouldUseService() {
+                    context.registerInjectActivateService(new HelloService());
+                    assertNotNull(context.getService(HelloService.class));
                 }
             }
         """)

--- a/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
@@ -79,7 +79,9 @@ class BundlePlugin : CommonDefaultPlugin() {
         }
     }
 
-    // @see <https://github.com/Cognifide/gradle-aem-plugin/issues/95>
+    /**
+     * @see <https://github.com/Cognifide/gradle-aem-plugin/issues/95>
+     */
     private fun Project.setupTestTask() = afterEvaluate {
         tasks {
             named<Test>(JavaPlugin.TEST_TASK_NAME) {

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/InstanceManager.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/InstanceManager.kt
@@ -31,7 +31,7 @@ open class InstanceManager(val aem: AemExtension) {
      * Directory storing instance wide configuration files.
      */
     val configDir = aem.obj.dir {
-        convention(projectDir.dir("src/aem/instance"))
+        convention(projectDir.dir(aem.prop.string("instance.configPath") ?: "src/aem/instance"))
         aem.prop.file("instance.configDir")?.let { set(it) }
     }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstanceManager.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstanceManager.kt
@@ -48,7 +48,7 @@ class LocalInstanceManager(private val aem: AemExtension) : Serializable {
      * Path for storing local AEM instances related resources.
      */
     val configDir = aem.obj.dir {
-        convention(projectDir.dir("src/aem/localInstance"))
+        convention(projectDir.dir(aem.prop.string("localInstance.configPath") ?: "src/aem/localInstance"))
         aem.prop.file("localInstance.configDir")?.let { set(it) }
     }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/BackupManager.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/BackupManager.kt
@@ -228,7 +228,7 @@ class BackupManager(private val aem: AemExtension) {
     }
 
     companion object {
-        const val OUTPUT_DIR = "instance/backup"
+        const val OUTPUT_DIR = "localInstance/backup"
 
         const val SUFFIX_DEFAULT = ".backup.zip"
     }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/InstallResolver.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/InstallResolver.kt
@@ -9,7 +9,7 @@ class InstallResolver(private val aem: AemExtension) {
     private val common = aem.common
 
     private val fileResolver = FileResolver(common).apply {
-        downloadDir.convention(aem.obj.buildDir("instance/install"))
+        downloadDir.convention(aem.obj.buildDir("localInstance/install"))
         aem.prop.file("localInstance.install.downloadDir")?.let { downloadDir.set(it) }
         aem.prop.list("localInstance.install.urls")?.forEachIndexed { index, url ->
             val no = index + 1

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/provision/Condition.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/provision/Condition.kt
@@ -36,7 +36,7 @@ class Condition(val step: InstanceStep) {
     /**
      * Perform step only once regardless if it fails or not.
      */
-    fun ultimateOnce() = !step.ended
+    fun ultimateOnce() = !step.ended || step.changed
 
     /**
      * Repeat performing step after specified number of milliseconds since last time.

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/provision/InstanceStep.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/provision/InstanceStep.kt
@@ -24,6 +24,10 @@ class InstanceStep(val instance: Instance, val definition: Step) {
 
     val ended: Boolean get() = marker.exists && marker.hasProperty(ENDED_AT_PROP)
 
+    val version: Long get() = marker.takeIf { it.exists }?.properties?.long(VERSION_PROP) ?: 1L
+
+    val changed: Boolean get() = version != definition.version
+
     val endedAt: Date
         get() = marker.properties.date(ENDED_AT_PROP)
                 ?: throw ProvisionException("Provision step '${definition.id}' not yet ended on $instance!")
@@ -70,11 +74,13 @@ class InstanceStep(val instance: Instance, val definition: Step) {
                 }
             }
             marker.save(mapOf(
+                    VERSION_PROP to definition.version,
                     ENDED_AT_PROP to Date(),
                     FAILED_PROP to false
             ))
         } catch (e: Exception) {
             marker.save(mapOf(
+                    VERSION_PROP to definition.version,
                     ENDED_AT_PROP to Date(),
                     FAILED_PROP to true
             ))
@@ -96,5 +102,7 @@ class InstanceStep(val instance: Instance, val definition: Step) {
         const val FAILED_PROP = "failed"
 
         const val COUNTER_PROP = "counter"
+
+        const val VERSION_PROP = "version"
     }
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/provision/Provisioner.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/provision/Provisioner.kt
@@ -75,7 +75,7 @@ class Provisioner(val manager: InstanceManager) {
             }
         }
 
-        if (actions.isEmpty()) {
+        if (actions.none { it.status != Status.SKIPPED }) {
             logger.lifecycle("No steps to perform / all instances provisioned.")
         }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/provision/Step.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/provision/Step.kt
@@ -20,6 +20,11 @@ class Step(val provisioner: Provisioner, val id: String) {
     var description: String? = null
 
     /**
+     * Implementation version number.
+     */
+    var version: Long = 1L
+
+    /**
      * Allows to redo step action after delay if exception is thrown.
      */
     var retry: Retry = common.retry { afterSquaredSecond(aem.prop.long("instance.provision.step.retry") ?: 0L) }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/pkg/PackageOptions.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/pkg/PackageOptions.kt
@@ -9,12 +9,12 @@ class PackageOptions(private val aem: AemExtension) : Serializable {
     /**
      * Package specific configuration
      */
-    val configDir = aem.obj.projectDir("src/aem/package")
+    val configDir = aem.obj.projectDir(aem.prop.string("package.configPath") ?: "src/aem/package")
 
     /**
      * Package root directory containing 'jcr_root' and 'META-INF' directories.
      */
-    val contentDir = aem.obj.projectDir("src/main/content")
+    val contentDir = aem.obj.projectDir(aem.prop.string("package.contentPath") ?: "src/main/content")
 
     /**
      * JCR root directory.
@@ -35,11 +35,12 @@ class PackageOptions(private val aem: AemExtension) : Serializable {
     /**
      * Content path for OSGi bundle jars being placed in CRX package.
      *
-     * Default convention assumes that subprojects have separate bundle paths, because of potential re-installation of subpackages.
-     * When all subprojects will have same bundle path, reinstalling one subpackage may end with deletion of other bundles coming from another subpackage.
+     * Default convention assumes that sub-projects have separate bundle paths, because of potential re-installation of sub-packages.
+     * When all sub-projects will have same bundle path, reinstalling one sub-package may end with deletion of other bundles coming from another sub-package.
+     * As a consequence, generally it is recommended to avoid providing value by putting it into properties file.
      *
      * Beware that more nested bundle install directories are not supported by AEM by default (up to 4th depth level).
-     * That's the reason of using dots in subproject names to avoid that limitation.
+     * That's the reason of using dots in sub-project names to avoid that limitation.
      */
     val installPath = aem.obj.string {
         convention(aem.obj.provider {
@@ -48,18 +49,25 @@ class PackageOptions(private val aem: AemExtension) : Serializable {
                 else -> "/apps/${aem.project.rootProject.name}/${aem.project.name}/install"
             }
         })
+        aem.prop.string("package.installPath")?.let { set(it) }
     }
 
     /**
      * Content path at which CRX Package Manager is storing uploaded packages.
      */
-    val storagePath = aem.obj.string { convention("/etc/packages") }
+    val storagePath = aem.obj.string {
+        convention("/etc/packages")
+        aem.prop.string("package.storagePath")?.let { set(it) }
+    }
 
     /**
      * Configures a local repository from which unreleased JARs could be added as 'compileOnly' dependency
      * and be deployed within CRX package deployment.
      */
-    val installRepository = aem.obj.boolean { convention(true) }
+    val installRepository = aem.obj.boolean {
+        convention(true)
+        aem.prop.boolean("package.installRepository")?.let { set(it) }
+    }
 
     /**
      * Customize default validation options.

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/tasks/InstanceStatus.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/tasks/InstanceStatus.kt
@@ -6,14 +6,19 @@ import com.cognifide.gradle.common.utils.Formats
 import com.cognifide.gradle.common.utils.onEachApply
 import de.vandermeer.asciitable.AsciiTable
 import de.vandermeer.skb.interfaces.transformers.textformat.TextAlignment
-import org.gradle.api.Incubating
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
-@Incubating
 open class InstanceStatus : InstanceTask() {
 
+    @Internal
+    val detailed = aem.obj.boolean {
+        convention(logger.isInfoEnabled)
+        aem.prop.boolean("instance.status.detailed")?.let { set(it) }
+    }
+
     @TaskAction
-    @Suppress("MagicNumber", "LongMethod")
+    @Suppress("MagicNumber", "LongMethod", "TooGenericExceptionCaught")
     fun status() {
         val table = common.progress(instances.get().size) {
             AsciiTable().apply {
@@ -45,7 +50,7 @@ open class InstanceStatus : InstanceTask() {
                                     add("Run path: $runningPath")
                                     add("Run modes: ${runningModes.joinToString(",")}")
 
-                                    if (logger.isInfoEnabled) {
+                                    if (detailed.get()) {
                                         add("Time zone: ${zoneId.id} (GMT${zoneOffset.id})")
                                         add("Operating system: $osInfo")
                                         add("Java: $javaInfo")
@@ -54,9 +59,9 @@ open class InstanceStatus : InstanceTask() {
                             }.joinToString("<br>")
 
                             val packagesInstalled = if (available) {
-                                sync {
-                                    aem.packagesBuilt.sortedBy { it.path }.map { task ->
-                                        sync {
+                                try {
+                                    sync {
+                                        aem.packagesBuilt.sortedBy { it.path }.mapNotNull { task ->
                                             val pkg = packageManager.find(task.vaultDefinition)
                                             val path = task.path.removeSuffix(":${task.name}")
 
@@ -65,9 +70,11 @@ open class InstanceStatus : InstanceTask() {
                                             } else {
                                                 "$path (not yet)"
                                             }
-                                        }
-                                    }.joinToString("<br>")
-                                }.ifBlank { "none" }
+                                        }.joinToString("<br>")
+                                    }.ifBlank { "none" }
+                                } catch (e: Exception) {
+                                    "unknown"
+                                }
                             } else {
                                 "unknown"
                             }
@@ -86,7 +93,7 @@ open class InstanceStatus : InstanceTask() {
     }
 
     init {
-        description = "Prints out status of all AEM instances."
+        description = "Prints status of all AEM instances."
     }
 
     companion object {

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/tasks/InstanceStatus.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/tasks/InstanceStatus.kt
@@ -55,13 +55,15 @@ open class InstanceStatus : InstanceTask() {
 
                             val packagesInstalled = if (available) {
                                 sync {
-                                    aem.packagesBuilt.map { task ->
+                                    aem.packagesBuilt.sortedBy { it.path }.map { task ->
                                         sync {
                                             val pkg = packageManager.find(task.vaultDefinition)
+                                            val path = task.path.removeSuffix(":${task.name}")
+
                                             if (pkg != null && pkg.installed) {
-                                                "${task.path} (${Formats.date(date(pkg.lastUnpacked!!))})"
+                                                "$path (${Formats.date(date(pkg.lastUnpacked!!))})"
                                             } else {
-                                                "${task.path} (not yet)"
+                                                "$path (not yet)"
                                             }
                                         }
                                     }.joinToString("<br>")

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
@@ -2,7 +2,6 @@ package com.cognifide.gradle.aem.pkg
 
 import com.cognifide.gradle.aem.AemExtension
 import com.cognifide.gradle.aem.bundle.BundlePlugin
-import com.cognifide.gradle.aem.bundle.tasks.BundleCompose
 import com.cognifide.gradle.aem.common.CommonPlugin
 import com.cognifide.gradle.aem.common.tasks.PackageTask
 import com.cognifide.gradle.aem.instance.InstancePlugin
@@ -13,8 +12,6 @@ import com.cognifide.gradle.common.tasks.configureApply
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Dependency
-import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.tasks.testing.Test
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
 class PackagePlugin : CommonDefaultPlugin() {
@@ -52,13 +49,9 @@ class PackagePlugin : CommonDefaultPlugin() {
         }.apply {
             artifacts.add(Dependency.ARCHIVES_CONFIGURATION, this)
 
-            if (plugins.hasPlugin(BundlePlugin::class.java)) {
-                val test = named<Test>(JavaPlugin.TEST_TASK_NAME)
-                val bundle = named<BundleCompose>(BundleCompose.NAME)
-
-                configureApply {
-                    installBundleBuilt(bundle)
-                    dependsOn(test)
+            afterEvaluate {
+                if (plugins.hasPlugin(BundlePlugin::class.java)) {
+                    configureApply { installBundleProject(project.path) }
                 }
             }
         }

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/PackageCompose.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/PackageCompose.kt
@@ -15,6 +15,7 @@ import com.cognifide.gradle.common.utils.using
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.*
 
@@ -171,7 +172,10 @@ open class PackageCompose : ZipTask(), AemTask {
         vaultDefinition.nodeTypeLines.addAll(other.nodeTypeLines)
     }
 
-    fun mergePackageProject(projectPath: String) = mergePackage("$projectPath:$NAME")
+    fun mergePackageProject(projectPath: String) {
+        mergePackage("$projectPath:$NAME")
+        dependsOn("$projectPath:${PackageValidate.NAME}")
+    }
 
     fun mergePackage(taskPath: String) = mergePackage(common.tasks.pathed(taskPath))
 
@@ -185,6 +189,7 @@ open class PackageCompose : ZipTask(), AemTask {
 
     fun nestPackageProject(projectPath: String, options: PackageNestedBuilt.() -> Unit = {}) {
         nestPackageBuilt("$projectPath:$NAME", options)
+        dependsOn("$projectPath:${PackageValidate.NAME}")
     }
 
     fun nestPackageBuilt(taskPath: String, options: PackageNestedBuilt.() -> Unit = {}) {
@@ -204,6 +209,7 @@ open class PackageCompose : ZipTask(), AemTask {
 
     fun installBundleProject(projectPath: String, options: BundleInstalledBuilt.() -> Unit = {}) {
         installBundleBuilt("$projectPath:${BundleCompose.NAME}", options)
+        dependsOn("$projectPath:${JavaPlugin.TEST_TASK_NAME}")
     }
 
     fun installBundleBuilt(taskPath: String, options: BundleInstalledBuilt.() -> Unit = {}) {

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/PackageCompose.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/PackageCompose.kt
@@ -6,7 +6,6 @@ import com.cognifide.gradle.aem.bundle.tasks.BundleCompose
 import com.cognifide.gradle.aem.common.instance.service.pkg.Package
 import com.cognifide.gradle.aem.common.pkg.PackageException
 import com.cognifide.gradle.aem.common.pkg.PackageFileFilter
-import com.cognifide.gradle.aem.common.pkg.PackageValidator
 import com.cognifide.gradle.aem.common.pkg.vault.FilterFile
 import com.cognifide.gradle.aem.common.pkg.vault.FilterType
 import com.cognifide.gradle.aem.common.pkg.vault.VaultDefinition
@@ -19,7 +18,6 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.*
 
-@Suppress("TooManyFunctions")
 open class PackageCompose : ZipTask(), AemTask {
 
     final override val aem = project.aem
@@ -56,16 +54,6 @@ open class PackageCompose : ZipTask(), AemTask {
      */
     @Internal
     val nestedPath = aem.obj.string { convention(aem.packageOptions.storagePath) }
-
-    @Nested
-    val validator = PackageValidator(aem).apply {
-        workDir.convention(destinationDirectory.dir(Package.OAKPAL_OPEAR_PATH))
-        planName.convention("plan-compose.json")
-    }
-
-    fun validator(options: PackageValidator.() -> Unit) {
-        validator.apply(options)
-    }
 
     /**
      * Defines properties being used to generate CRX package metadata files.
@@ -106,12 +94,6 @@ open class PackageCompose : ZipTask(), AemTask {
     override fun projectsEvaluated() {
         super.projectsEvaluated()
         (definitions + definition).forEach { it() }
-    }
-
-    @TaskAction
-    override fun copy() {
-        super.copy()
-        validator.perform(composedFile)
     }
 
     fun fromDefaults() {

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/PackageCompose.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/PackageCompose.kt
@@ -172,10 +172,7 @@ open class PackageCompose : ZipTask(), AemTask {
         vaultDefinition.nodeTypeLines.addAll(other.nodeTypeLines)
     }
 
-    fun mergePackageProject(projectPath: String) {
-        mergePackage("$projectPath:$NAME")
-        dependsOn("$projectPath:${PackageValidate.NAME}")
-    }
+    fun mergePackageProject(projectPath: String) = mergePackage("$projectPath:$NAME")
 
     fun mergePackage(taskPath: String) = mergePackage(common.tasks.pathed(taskPath))
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/PackageValidate.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/PackageValidate.kt
@@ -1,0 +1,34 @@
+package com.cognifide.gradle.aem.pkg.tasks
+
+import com.cognifide.gradle.aem.AemDefaultTask
+import com.cognifide.gradle.aem.common.pkg.PackageValidator
+import org.gradle.api.tasks.*
+
+open class PackageValidate : AemDefaultTask() {
+
+    @InputFiles
+    val packages = aem.obj.files()
+
+    @Nested
+    val validator = PackageValidator(aem).apply {
+        workDir.convention(aem.obj.buildDir(name))
+        planName.convention("plan-compose.json")
+    }
+
+    fun validator(options: PackageValidator.() -> Unit) {
+        validator.apply(options)
+    }
+
+    @TaskAction
+    fun validate() {
+        validator.perform(packages.files)
+    }
+
+    init {
+        description = "Validates built CRX package"
+    }
+
+    companion object {
+        const val NAME = "packageValidate"
+    }
+}


### PR DESCRIPTION
impl of #660 #542 ; @sabberworm 

when using `nestPackageProject` or `installBundleProject` building assembly package will also cause running unit tests for installed bundle and package validation for nested package.

