### PR TITLE
Package config sync task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ repositories {
 dependencies {
     implementation(gradleApi())
 
-    implementation("com.cognifide.gradle:common-plugin:0.1.30")
+    implementation("com.cognifide.gradle:common-plugin:0.1.31")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.10.1")
     implementation("com.jayway.jsonpath:json-path:2.4.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.dokka.gradle.DokkaTask
+import io.gitlab.arturbosch.detekt.Detekt
 
 plugins {
     id("java-gradle-plugin")
@@ -7,7 +8,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version "1.3.70"
     id("org.jetbrains.dokka") version "0.10.1"
     id("com.gradle.plugin-publish") version "0.10.1"
-    id("io.gitlab.arturbosch.detekt") version "1.6.0"
+    id("io.gitlab.arturbosch.detekt") version "1.7.0"
     id("com.jfrog.bintray") version "1.8.4"
     id("net.researchgate.release") version "2.8.1"
     id("com.github.breadmoirai.github-release") version "2.2.10"
@@ -34,7 +35,7 @@ repositories {
 dependencies {
     implementation(gradleApi())
 
-    implementation("com.cognifide.gradle:common-plugin:0.1.32")
+    implementation("com.cognifide.gradle:common-plugin:0.1.33")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.10.1")
     implementation("com.jayway.jsonpath:json-path:2.4.0")
@@ -52,7 +53,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.5.2")
 
-    "detektPlugins"("io.gitlab.arturbosch.detekt:detekt-formatting:1.6.0")
+    "detektPlugins"("io.gitlab.arturbosch.detekt:detekt-formatting:1.7.0")
 }
 
 tasks {
@@ -93,12 +94,16 @@ tasks {
         }
     }
 
+    withType<Detekt>().configureEach {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
+
     withType<Test>().configureEach {
         testLogging.showStandardStreams = true
         useJUnitPlatform()
     }
 
-    named<Test>("test") {
+    test {
         dependsOn("detektTest")
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ repositories {
 dependencies {
     implementation(gradleApi())
 
-    implementation("com.cognifide.gradle:common-plugin:0.1.31")
+    implementation("com.cognifide.gradle:common-plugin:0.1.32")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.10.1")
     implementation("com.jayway.jsonpath:json-path:2.4.0")

--- a/docs/package-sync-plugin.md
+++ b/docs/package-sync-plugin.md
@@ -16,6 +16,9 @@
      * [Copying or cleaning content only](#copying-or-cleaning-content-only)
      * [Filter file at custom path](#filter-file-at-custom-path)
      * [Filter roots specified explicitly](#filter-roots-specified-explicitly)
+  * [Task packageConfig](#task-packageconfig)
+     * [Synchronizing configuration for built code](#synchronizing-configuration-for-built-code)
+     * [Synchronizing configuration for specified PID](#synchronizing-configuration-for-specified-pid)
   * [Task packageVlt](#task-packagevlt)
   * [Known issues](#known-issues)
      * [Vault tasks parallelism](#vault-tasks-parallelism)
@@ -199,6 +202,50 @@ gradlew :site.demo:packageSync -Pfilter.path=C:/aem/custom-filter.xml
    
 ```bash
 gradlew :site.demo:packageSync -Pfilter.roots=[/etc/tags/example,/content/dam/example]
+```
+
+## Task `packageConfig`
+
+Synchronizes OSGi configuration as XML files put into JCR content.
+
+First of all, changing OSGi configuration by hand using GUI dialog when accessing */system/console/configMgr* is not recommended.
+Instead, configuration changes should be applied by providing OSGi config node in built CRX package under path _/apps/${appName}/config_.
+Such file could be created from scratch, but this is generally speaking error-prone process, because of escaping forbidden characters and delimiters, type casts etc.
+
+To simplify that process, task `packageConfig` could be used. 
+It will download actual OSGi configuration values as XML file and put it at desired path to be later deployed within built CRX package.
+
+Alternatively, customized values could be set on OSGi configuration GUI dialog then task `packageConfig` could be run to synchronize changes and save them in VCS in a proper format.
+However that approach has a little disadvantage. After changing anything by hand on OSGi configuration dialog, changes done in XML files for appropriate OSGi configuration might be longer reflected on dialog after installing CRX package.
+Then, as a workaround, try with deleting configuration using button on dialog then update values in XML and deploy package again to restore binding.
+
+### Synchronizing configuration for built code
+
+```bash
+gradlew :app:aem:ui.apps:packageConfig
+```
+
+Output:
+
+```
+Synchronized OSGi configuration XML file(s) (1) matching PID 'com.company.example.aem.core.*':
+/Users/krystian.panek/Projects/gradle-aem-multi/app/aem/ui.apps/src/main/content/jcr_root/apps/example/config/com.company.example.aem.core.schedulers.SimpleScheduledTask.xml
+```
+
+### Synchronizing configuration for specified PID
+
+```bash
+gradlew :app:aem:ui.apps:packageConfig -Ppackage.config.pid=org.apache.sling.jcr.*
+```
+
+Output:
+
+```
+Synchronized OSGi configuration XML file(s) (20) matching PID 'org.apache.sling.jcr.*':
+/Users/krystian.panek/Projects/gradle-aem-multi/app/aem/ui.apps/src/main/content/jcr_root/apps/example/config/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.xml
+/Users/krystian.panek/Projects/gradle-aem-multi/app/aem/ui.apps/src/main/content/jcr_root/apps/example/config/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-cq-assets.xml
+...
+/Users/krystian.panek/Projects/gradle-aem-multi/app/aem/ui.apps/src/main/content/jcr_root/apps/example/config/org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet.xml
 ```
 
 ## Task `packageVlt`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=11.1.0
+version=12.0.0
 release.useAutomaticVersion=true
 org.gradle.jvmargs=-Xmx1024m

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/file/ZipFile.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/file/ZipFile.kt
@@ -11,7 +11,7 @@ import java.io.File
 /**
  * Only Zip4j correctly extracts AEM backup ZIP files (files bigger than 10 GB)
  */
-class ZipFile(private val baseFile: File) {
+class ZipFile(val baseFile: File) {
 
     private val base = Base(baseFile)
 
@@ -44,6 +44,18 @@ class ZipFile(private val baseFile: File) {
                     .filter { it.fileName.startsWith(dirFileName) }
                     .forEach { extractFile(it, dir.absolutePath) }
         }
+    }
+
+    fun unpackFile(fileName: String, targetFile: File) {
+        if (!contains(fileName)) {
+            throw ZipException("ZIP file '$baseFile' does not contain file '$fileName'!")
+        }
+
+        base.extractFile(fileName, targetFile.parentFile.absolutePath, targetFile.name)
+    }
+
+    fun unpackFileTo(fileName: String, targetDir: File) {
+        unpackFile(fileName, targetDir.resolve(fileName.substringAfterLast("/")))
     }
 
     fun addDir(sourceDir: File, options: ZipParameters.() -> Unit = {}) {

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/pkg/PackageValidator.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/pkg/PackageValidator.kt
@@ -83,7 +83,7 @@ class PackageValidator(@Internal val aem: AemExtension) {
 
     // TODO https://github.com/gradle/gradle/issues/2016
     @Internal
-    val configDir = aem.obj.relativeDir(aem.packageOptions.configDir, Package.OAKPAL_OPEAR_PATH)
+    val configDir = aem.obj.relativeDir(aem.packageOptions.commonDir, Package.OAKPAL_OPEAR_PATH)
 
     @InputFiles
     val configFiles = aem.obj.files { from(configDir) }

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
@@ -29,9 +29,8 @@ class PackagePlugin : CommonDefaultPlugin() {
     private fun Project.setupInstallRepository() = afterEvaluate {
         val packageOptions = AemExtension.of(this).packageOptions
         if (packageOptions.installRepository.get()) {
-            val installDir = file("${packageOptions.jcrRootDir.get().asFile}${packageOptions.installPath}")
-            if (installDir.exists()) {
-                repositories.flatDir { it.dir(installDir) }
+            if (packageOptions.installDir.get().asFile.exists()) {
+                repositories.flatDir { it.dir(packageOptions.installDir.get().asFile) }
             }
         }
     }

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackageSyncPlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackageSyncPlugin.kt
@@ -1,6 +1,7 @@
 package com.cognifide.gradle.aem.pkg
 
 import com.cognifide.gradle.aem.common.CommonPlugin
+import com.cognifide.gradle.aem.pkg.tasks.PackageConfig
 import com.cognifide.gradle.aem.pkg.tasks.PackageSync
 import com.cognifide.gradle.aem.pkg.tasks.PackageVlt
 import com.cognifide.gradle.common.CommonDefaultPlugin
@@ -24,12 +25,12 @@ class PackageSyncPlugin : CommonDefaultPlugin() {
 
     private fun Project.setupTasks() = tasks {
         val clean = named<Task>(LifecycleBasePlugin.CLEAN_TASK_NAME)
-        register<PackageVlt>(PackageVlt.NAME) {
-            mustRunAfter(clean)
-        }
+
+        register<PackageVlt>(PackageVlt.NAME)
         register<PackageSync>(PackageSync.NAME) {
             mustRunAfter(clean)
         }
+        register<PackageConfig>(PackageConfig.NAME)
     }
 
     companion object {

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/PackageConfig.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/PackageConfig.kt
@@ -1,0 +1,59 @@
+package com.cognifide.gradle.aem.pkg.tasks
+
+import com.cognifide.gradle.aem.AemDefaultTask
+import com.cognifide.gradle.aem.common.file.ZipFile
+import com.cognifide.gradle.aem.common.instance.Instance
+import com.cognifide.gradle.aem.common.instance.service.pkg.Package
+import com.cognifide.gradle.aem.common.pkg.PackageException
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+open class PackageConfig : AemDefaultTask() {
+
+    /**
+     * Source instance from which OSGi config will be read.
+     */
+    @Internal
+    val instance = aem.obj.typed<Instance> { convention(aem.obj.provider { aem.anyInstance }) }
+
+    /**
+     * Root repository path used to store temporarily OSGi configs for a serialization time only.
+     */
+    @Internal
+    val rootPath = aem.obj.string { convention("/var/gap/package/config") }
+
+    /**
+     * Target directory in which OSGi configs read will be saved.
+     */
+    @Internal
+    val saveDir = aem.obj.dir { convention(aem.packageOptions.configDir) }
+
+    /**
+     * Unique ID of OSGi config to be saved.
+     */
+    @Internal
+    val pid = aem.obj.string { convention(aem.prop.string("package.config.pid")) }
+
+    @TaskAction
+    fun saveOsgiConfig() = instance.get().sync {
+        val pid = pid.orNull ?: throw PackageException("OSGi config PID is not specified!")
+        val config = osgi.getConfiguration(pid)
+
+        val rootNode = repository.node(rootPath.get())
+        rootNode.import(config.properties + mapOf("jcr:primaryType" to "sling:OsgiConfig"), pid, true)
+
+        val configNode = rootNode.child(pid)
+        val configPkg = configNode.downloadPackage()
+        val configZip  = ZipFile(configPkg)
+        configZip.unpackFileTo("${Package.JCR_ROOT}${configNode.path}.xml", saveDir.get().asFile)
+        configPkg.delete()
+    }
+
+    init {
+        description = "Saves current OSGi configuration of given PID as XML file being a part of JCR content."
+    }
+
+    companion object {
+        const val NAME = "packageConfig"
+    }
+}


### PR DESCRIPTION
impl of #654 

imagine:

sh gradlew :app:aem:ui.apps:packageConfig -Ppackage.config.pid=org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet  

then GAP will retrieve OSGi config, serialize it and download and put it into app/aem/ui.apps/src/main/content/jcr_root/apps/example/config/org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet.xml  

PID specified could have wildcards to sync multiple configs at once

![image](https://user-images.githubusercontent.com/10673561/77472877-db8be080-6e14-11ea-8644-3b685bbd4913.png)

motivation?

when saving OSGI configuration it is needed to rewrite properties from /system/console/configMgr/{pid} window displayed, then values need to be rewritten with type casts, comma delimited and escaped. Many things that we could do wrong. This new task eliminates many problems when transferring OSGi configuration to VCS.
