### PR TITLE
Easy package and bundle Maven publication with Gradle metadata support

### DIFF
--- a/docs/bundle-plugin.md
+++ b/docs/bundle-plugin.md
@@ -11,6 +11,7 @@
   * [Embedding JAR file into OSGi bundle](#embedding-jar-file-into-osgi-bundle)
   * [Configuring OSGi bundle manifest attributes](#configuring-osgi-bundle-manifest-attributes)
   * [Excluding packages being incidentally imported by OSGi bundle](#excluding-packages-being-incidentally-imported-by-osgi-bundle)
+  * [Publishing bundles](#publishing-bundles)
   * [Task bundleInstall](#task-bundleinstall)
   * [Task bundleUninstall](#task-bundleuninstall)
   * [Known issues](#known-issues)
@@ -129,6 +130,36 @@ aem {
     }
 }
 ```
+
+### Publishing bundles
+
+Simply add following snippets to file _build.gradle.kts_ for each project applying bundle plugin.
+
+```kotlin
+plugins {
+    id("com.cognifide.aem.bundle")
+    id("maven-publish")
+}
+
+publishing {
+    repositories {
+        maven {
+            // specify here e.g Nexus URL and credentials
+        }   
+    }
+
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["aem"])
+        }
+    }
+}
+```
+
+To publish bundle to repository (upload it to e.g Nexus repository) simply run one of [publish tasks](https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:tasks) (typically `publish`).
+
+It might be worth to configure [publishing repositories](https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:repositories) globally. Consider moving `publishing { repositories { /* ... */ } }` section to root project's _build.gradle.kts_ into `allprojects { }` section. 
+Then defining publishing repositories in each subproject will be no longer necessary.
 
 ## Task `bundleInstall`
 

--- a/docs/package-plugin.md
+++ b/docs/package-plugin.md
@@ -15,6 +15,7 @@
      * [Nesting CRX packages](#nesting-crx-packages)
      * [Assembling packages (merging all-in-one)](#assembling-packages-merging-all-in-one)
      * [Expandable properties](#expandable-properties)
+     * [Publishing packages](#publishing-packages)
   * [Task packagePrepare](#task-packageprepare)
   * [Task packageValidate](#task-packagevalidate)
   * [Task packageDeploy](#task-packagedeploy)
@@ -347,6 +348,36 @@ This feature is especially useful to generate valid *META-INF/properties.xml* fi
 Also file *nodetypes.cnd* is dynamically expanded from [template](src/main/resources/com/cognifide/gradle/aem/package/META-INF/vault/nodetypes.cnd) to generate file containing all node types from all sub packages being merged into assembly package.
 
 Each JAR file in separate *hooks* directory will be combined into single directory when creating assembly package.
+
+### Publishing packages
+
+Simply add following snippets to file _build.gradle.kts_ for each project applying package plugin.
+
+```kotlin
+plugins {
+    id("com.cognifide.aem.package")
+    id("maven-publish")
+}
+
+publishing {
+    repositories {
+        maven {
+            // specify here e.g Nexus URL and credentials
+        }   
+    }
+
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["aem"])
+        }
+    }
+}
+```
+
+To publish package to repository (upload it to e.g Nexus repository) simply run one of [publish tasks](https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:tasks) (typically `publish`).
+
+It might be worth to configure [publishing repositories](https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:repositories) globally. Consider moving `publishing { repositories { /* ... */ } }` section to root project's _build.gradle.kts_ into `allprojects { }` section. 
+Then defining publishing repositories in each subproject will be no longer necessary.
 
 ## Task `packagePrepare`
 

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/bundle/BundlePluginTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/bundle/BundlePluginTest.kt
@@ -3,7 +3,6 @@ package com.cognifide.gradle.aem.bundle
 import com.cognifide.gradle.aem.test.AemBuildTest
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
-import java.io.File
 
 @Suppress("LongMethod", "MaxLineLength")
 class BundlePluginTest : AemBuildTest() {
@@ -98,8 +97,12 @@ class BundlePluginTest : AemBuildTest() {
                 }
                 
                 publishing {
+                    repositories {
+                        maven(rootProject.file("build/repository"))
+                    }
+                
                     publications {
-                        create<MavenPublication>("mavenJava") {
+                        create<MavenPublication>("maven") {
                             from(components["aem"])
                         }
                     }
@@ -114,10 +117,10 @@ class BundlePluginTest : AemBuildTest() {
             assertBundle("build/bundleCompose/bundle-extended-1.0.0.jar")
         }
 
-        runBuild(projectDir, "publishToMavenLocal", "-Poffline") {
+        runBuild(projectDir, "publish", "-Poffline") {
             assertTask(":bundleCompose", TaskOutcome.UP_TO_DATE)
 
-            val mavenDir = File("${System.getProperty("user.home")}/.m2/repository/com/company/example/bundle-extended/1.0.0")
+            val mavenDir = projectDir.resolve("build/repository/com/company/example/bundle-extended/1.0.0")
             assertFileExists(mavenDir.resolve("bundle-extended-1.0.0.jar"))
             assertFileExists(mavenDir.resolve("bundle-extended-1.0.0.pom"))
             assertFileExists(mavenDir.resolve("bundle-extended-1.0.0.module"))

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/bundle/BundlePluginTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/bundle/BundlePluginTest.kt
@@ -9,7 +9,7 @@ import java.io.File
 class BundlePluginTest : AemBuildTest() {
 
     @Test
-    fun `should build package with bundle using minimal configuration`() {
+    fun `should build bundle using minimal configuration`() {
         val projectDir = prepareProject("bundle-minimal") {
             settingsGradle("")
 
@@ -49,7 +49,7 @@ class BundlePluginTest : AemBuildTest() {
     }
 
     @Test
-    fun `should build package with bundle using extended configuration`() {
+    fun `should build bundle using extended configuration`() {
         val projectDir = prepareProject("bundle-extended") {
             /**
              * This is not required here but it proves that there is some issue with Gradle TestKit;
@@ -100,7 +100,7 @@ class BundlePluginTest : AemBuildTest() {
                 publishing {
                     publications {
                         create<MavenPublication>("mavenJava") {
-                            from(components["java"])
+                            from(components["aem"])
                         }
                     }
                 }

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
@@ -356,6 +356,8 @@ class PackagePluginTest : AemBuildTest() {
             
             tasks {
                 packageCompose {
+                    installBundleBuilt()
+                
                     vaultDefinition {
                         property("installhook.actool.class", "biz.netcentric.cq.tools.actool.installhook.AcToolInstallHook")
                     }

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
@@ -110,7 +110,7 @@ class PackagePluginTest : AemBuildTest() {
                 publishing {
                     publications {
                         create<MavenPublication>("maven") {
-                            gradle.projectsEvaluated { artifact(tasks["packageCompose"]) }
+                            from(components["aem"])
                         }
                     }
                 }

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
@@ -107,7 +107,9 @@ class PackagePluginTest : AemBuildTest() {
                 }
 
                 publishing {
-                    
+                    repositories {
+                        maven(rootProject.file("build/repository"))
+                    }
                 
                     publications {
                         create<MavenPublication>("maven") {
@@ -193,8 +195,8 @@ class PackagePluginTest : AemBuildTest() {
             assertTask(":assembly:packageValidate")
         }
 
-        runBuild(projectDir, ":assembly:publishToMavenLocal", "-Poffline") {
-            val mavenDir = File("${System.getProperty("user.home")}/.m2/repository/com/company/example/aem/assembly/1.0.0")
+        runBuild(projectDir, ":assembly:publish", "-Poffline") {
+            val mavenDir = projectDir.resolve("build/repository/com/company/example/aem/assembly/1.0.0")
             assertFileExists(mavenDir.resolve("assembly-1.0.0.zip"))
             assertFileExists(mavenDir.resolve("assembly-1.0.0.pom"))
             assertFileExists(mavenDir.resolve("assembly-1.0.0.module"))

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
@@ -94,6 +94,7 @@ class PackagePluginTest : AemBuildTest() {
             file("assembly/build.gradle.kts", """
                 plugins {
                     id("com.cognifide.aem.package")
+                    id("maven-publish")
                 }
                 
                 group = "com.company.example.aem"
@@ -102,6 +103,15 @@ class PackagePluginTest : AemBuildTest() {
                     packageCompose {
                         mergePackageProject(":ui.apps")
                         mergePackageProject(":ui.content")
+                    }
+                }
+
+    
+                publishing {
+                    publications {
+                        create<MavenPublication>("maven") {
+                            gradle.projectsEvaluated { artifact(tasks["packageCompose"]) }
+                        }
                     }
                 }
             """)
@@ -181,6 +191,13 @@ class PackagePluginTest : AemBuildTest() {
             assertTask(":assembly:packageCompose", TaskOutcome.UP_TO_DATE)
             assertTask(":assembly:packageValidate")
         }
+//
+//        runBuild(projectDir, ":assembly:publishToMavenLocal", "-Poffline") {
+//            val mavenDir = File("${System.getProperty("user.home")}/.m2/repository/com/company/example/assembly/1.0.0")
+//            assertFileExists(mavenDir.resolve("example-assembly-1.0.0.jar"))
+//            assertFileExists(mavenDir.resolve("example-assembly-1.0.0.pom"))
+//            assertFileExists(mavenDir.resolve("example-assembly-1.0.0.module"))
+//        }
     }
 
     @Test

--- a/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
+++ b/src/functionalTest/kotlin/com/cognifide/gradle/aem/pkg/PackagePluginTest.kt
@@ -106,8 +106,9 @@ class PackagePluginTest : AemBuildTest() {
                     }
                 }
 
-    
                 publishing {
+                    
+                
                     publications {
                         create<MavenPublication>("maven") {
                             from(components["aem"])
@@ -191,13 +192,13 @@ class PackagePluginTest : AemBuildTest() {
             assertTask(":assembly:packageCompose", TaskOutcome.UP_TO_DATE)
             assertTask(":assembly:packageValidate")
         }
-//
-//        runBuild(projectDir, ":assembly:publishToMavenLocal", "-Poffline") {
-//            val mavenDir = File("${System.getProperty("user.home")}/.m2/repository/com/company/example/assembly/1.0.0")
-//            assertFileExists(mavenDir.resolve("example-assembly-1.0.0.jar"))
-//            assertFileExists(mavenDir.resolve("example-assembly-1.0.0.pom"))
-//            assertFileExists(mavenDir.resolve("example-assembly-1.0.0.module"))
-//        }
+
+        runBuild(projectDir, ":assembly:publishToMavenLocal", "-Poffline") {
+            val mavenDir = File("${System.getProperty("user.home")}/.m2/repository/com/company/example/aem/assembly/1.0.0")
+            assertFileExists(mavenDir.resolve("assembly-1.0.0.zip"))
+            assertFileExists(mavenDir.resolve("assembly-1.0.0.pom"))
+            assertFileExists(mavenDir.resolve("assembly-1.0.0.module"))
+        }
     }
 
     @Test
@@ -356,8 +357,6 @@ class PackagePluginTest : AemBuildTest() {
             
             tasks {
                 packageCompose {
-                    installBundleBuilt()
-                
                     vaultDefinition {
                         property("installhook.actool.class", "biz.netcentric.cq.tools.actool.installhook.AcToolInstallHook")
                     }

--- a/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
@@ -31,7 +31,6 @@ import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import javax.inject.Inject
 
-
 class BundlePlugin @Inject constructor(private val objectFactory: ObjectFactory) : CommonDefaultPlugin() {
 
     override fun Project.configureProject() {

--- a/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
@@ -13,14 +13,21 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition
+import org.gradle.api.attributes.Usage
+import org.gradle.api.component.AdhocComponentWithVariants
+import org.gradle.api.internal.artifacts.ArtifactAttributes
+import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginConvention
-import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
+import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import javax.inject.Inject
 
-class BundlePlugin : CommonDefaultPlugin() {
+class BundlePlugin @Inject constructor(private val objectFactory: ObjectFactory) : CommonDefaultPlugin() {
 
     override fun Project.configureProject() {
         setupDependentPlugins()
@@ -53,29 +60,41 @@ class BundlePlugin : CommonDefaultPlugin() {
         }
     }
 
-    private fun Project.setupTasks() = tasks {
-        val compose = register<BundleCompose>(BundleCompose.NAME) {
-            dependsOn(JavaPlugin.CLASSES_TASK_NAME)
-        }.apply {
-            artifacts.add(Dependency.ARCHIVES_CONFIGURATION, this)
-            artifacts.add(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME, this)
-            artifacts.add(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME, this)
-            artifacts.add(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME, this)
+    private fun Project.setupTasks() {
+        val configuration = configurations.create(CONFIGURATION) { c ->
+            c.attributes.attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage::class.java, Usage.JAVA_RUNTIME))
+            c.outgoing.attributes.attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.JAR_TYPE)
         }
-        register<BundleInstall>(BundleInstall.NAME) {
-            dependsOn(compose)
+
+        configurations.named(Dependency.ARCHIVES_CONFIGURATION) { it.extendsFrom(configuration) }
+        configurations.named(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME) { it.extendsFrom(configuration) }
+        configurations.named(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME) { it.extendsFrom(configuration) }
+        configurations.named(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME) { it.extendsFrom(configuration) }
+
+        components.named(CommonPlugin.COMPONENT).configure { component ->
+            if (component is AdhocComponentWithVariants) {
+                component.addVariantsFromConfiguration(configuration) { it.mapToMavenScope(MavenScope.Compile.lowerName) }
+            }
         }
-        register<BundleUninstall>(BundleUninstall.NAME) {
-            dependsOn(compose)
-        }
-        typed<BundleTask> {
-            files.from(compose.map { it.archiveFile })
-        }
-        named<Task>(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) {
-            dependsOn(compose)
-        }
-        named<Jar>(JavaPlugin.JAR_TASK_NAME) {
-            archiveClassifier.set(LIB_CLASSIFIER)
+
+        tasks {
+            val compose = register<BundleCompose>(BundleCompose.NAME) {
+                dependsOn(JavaPlugin.CLASSES_TASK_NAME)
+            }.apply {
+                configuration.outgoing.artifacts.add(LazyPublishArtifact(this))
+            }
+            register<BundleInstall>(BundleInstall.NAME) {
+                dependsOn(compose)
+            }
+            register<BundleUninstall>(BundleUninstall.NAME) {
+                dependsOn(compose)
+            }
+            typed<BundleTask> {
+                files.from(compose.map { it.archiveFile })
+            }
+            named<Task>(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) {
+                dependsOn(compose)
+            }
         }
     }
 
@@ -100,6 +119,6 @@ class BundlePlugin : CommonDefaultPlugin() {
     companion object {
         const val ID = "com.cognifide.aem.bundle"
 
-        const val LIB_CLASSIFIER = "lib"
+        const val CONFIGURATION = "aemBundle"
     }
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
@@ -14,6 +14,9 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.component.AdhocComponentWithVariants
 import org.gradle.api.internal.artifacts.ArtifactAttributes
@@ -26,6 +29,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import javax.inject.Inject
+
 
 class BundlePlugin @Inject constructor(private val objectFactory: ObjectFactory) : CommonDefaultPlugin() {
 
@@ -62,7 +66,12 @@ class BundlePlugin @Inject constructor(private val objectFactory: ObjectFactory)
 
     private fun Project.setupTasks() {
         val configuration = configurations.create(CONFIGURATION) { c ->
-            c.attributes.attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage::class.java, Usage.JAVA_RUNTIME))
+            c.attributes.apply {
+                attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage::class.java, Usage.JAVA_RUNTIME))
+                attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements::class.java, LibraryElements.JAR))
+                attribute(Bundling.BUNDLING_ATTRIBUTE, objectFactory.named(Bundling::class.java, Bundling.EXTERNAL))
+                attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category::class.java, Category.LIBRARY))
+            }
             c.outgoing.attributes.attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.JAR_TYPE)
         }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
@@ -67,7 +67,7 @@ class BundlePlugin @Inject constructor(private val objectFactory: ObjectFactory)
     private fun Project.setupTasks() {
         val configuration = configurations.create(CONFIGURATION) { c ->
             c.attributes.apply {
-                attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage::class.java, Usage.JAVA_RUNTIME))
+                attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage::class.java, Usage.JAVA_API))
                 attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements::class.java, LibraryElements.JAR))
                 attribute(Bundling.BUNDLING_ATTRIBUTE, objectFactory.named(Bundling::class.java, Bundling.EXTERNAL))
                 attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category::class.java, Category.LIBRARY))

--- a/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/bundle/BundlePlugin.kt
@@ -20,6 +20,7 @@ import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.component.AdhocComponentWithVariants
 import org.gradle.api.internal.artifacts.ArtifactAttributes
+import org.gradle.api.internal.artifacts.JavaEcosystemSupport
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPlugin
@@ -73,6 +74,9 @@ class BundlePlugin @Inject constructor(private val objectFactory: ObjectFactory)
                 attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category::class.java, Category.LIBRARY))
             }
             c.outgoing.attributes.attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.JAR_TYPE)
+            afterEvaluate {
+                JavaEcosystemSupport.configureDefaultTargetPlatform(c, convention.getPlugin(JavaPluginConvention::class.java).targetCompatibility)
+            }
         }
 
         configurations.named(Dependency.ARCHIVES_CONFIGURATION) { it.extendsFrom(configuration) }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/CommonPlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/CommonPlugin.kt
@@ -3,48 +3,27 @@ package com.cognifide.gradle.aem.common
 import com.cognifide.gradle.aem.AemExtension
 import com.cognifide.gradle.aem.AemPlugin
 import com.cognifide.gradle.common.CommonDefaultPlugin
-import java.util.*
 import org.gradle.api.Project
+import org.gradle.api.component.SoftwareComponentFactory
 import org.gradle.api.plugins.BasePlugin
+import javax.inject.Inject
 
 /**
  * Provides 'aem' extension to build script on which all other build logic is based.
  */
-class CommonPlugin : CommonDefaultPlugin() {
+class CommonPlugin @Inject constructor(private val componentFactory: SoftwareComponentFactory) : CommonDefaultPlugin() {
 
     override fun Project.configureProject() {
-        setupGreet()
-        setupDependentPlugins()
-        setupStructureProperties()
-        setupExtensions()
-    }
+        AemPlugin.apply { once { logger.info("Using: $NAME_WITH_VERSION") } }
 
-    private fun Project.setupGreet() = AemPlugin.apply {
-        once { logger.info("Using: $NAME_WITH_VERSION") }
-    }
-
-    private fun Project.setupDependentPlugins() {
         plugins.apply(BasePlugin::class.java)
-    }
-
-    private fun Project.setupStructureProperties() {
-        val file = project.rootProject.file(STRUCTURE_PROPERTIES_FILE)
-        if (file.exists()) {
-            file.bufferedReader().use { r ->
-                val props = Properties()
-                props.load(r)
-                props.forEach { k, v -> project.extensions.extraProperties.set(k as String, v) }
-            }
-        }
-    }
-
-    private fun Project.setupExtensions() {
         extensions.add(AemExtension.NAME, AemExtension(this))
+        components.add(componentFactory.adhoc(COMPONENT))
     }
 
     companion object {
         const val ID = "com.cognifide.aem.common"
 
-        const val STRUCTURE_PROPERTIES_FILE = "aem.properties"
+        const val COMPONENT = "aem"
     }
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
@@ -12,9 +12,17 @@ import com.cognifide.gradle.common.tasks.configureApply
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition
+import org.gradle.api.attributes.Usage
+import org.gradle.api.component.AdhocComponentWithVariants
+import org.gradle.api.internal.artifacts.ArtifactAttributes
+import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact
+import org.gradle.api.model.ObjectFactory
+import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import javax.inject.Inject
 
-class PackagePlugin : CommonDefaultPlugin() {
+class PackagePlugin @Inject constructor(private val objectFactory: ObjectFactory) : CommonDefaultPlugin() {
 
     override fun Project.configureProject() {
         setupDependentPlugins()
@@ -36,79 +44,94 @@ class PackagePlugin : CommonDefaultPlugin() {
     }
 
     @Suppress("LongMethod")
-    private fun Project.setupTasks() = tasks {
-        val clean = named<Task>(LifecycleBasePlugin.CLEAN_TASK_NAME)
-        val prepare = register<PackagePrepare>(PackagePrepare.NAME) {
-            mustRunAfter(clean)
+    private fun Project.setupTasks() {
+        val configuration = configurations.create(CONFIGURATION) { c ->
+            c.attributes.attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage::class.java, Usage.JAVA_RUNTIME))
+            c.outgoing.attributes.attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.ZIP_TYPE)
         }
-        val compose = register<PackageCompose>(PackageCompose.NAME) {
-            dependsOn(prepare)
-            mustRunAfter(clean)
-            metaDir.convention(prepare.flatMap { it.metaDir })
-        }.apply {
-            artifacts.add(Dependency.ARCHIVES_CONFIGURATION, this)
-
-            afterEvaluate {
-                if (plugins.hasPlugin(BundlePlugin::class.java)) {
-                    configureApply { installBundleProject(project.path) }
-                }
-            }
-        }
-        val validate = register<PackageValidate>(PackageValidate.NAME) {
-            dependsOn(compose)
-            packages.from(compose.flatMap { it.archiveFile })
-        }
-        val upload = register<PackageUpload>(PackageUpload.NAME) {
-            dependsOn(compose, validate)
-        }
-        val install = register<PackageInstall>(PackageInstall.NAME) {
-            dependsOn(compose, validate)
-            mustRunAfter(upload)
-        }
-        val uninstall = register<PackageUninstall>(PackageUninstall.NAME) {
-            dependsOn(compose, validate)
-            mustRunAfter(upload, install)
-        }
-        val activate = register<PackageActivate>(PackageActivate.NAME) {
-            dependsOn(compose, validate)
-            mustRunAfter(upload, install)
-        }
-        val deploy = register<PackageDeploy>(PackageDeploy.NAME) {
-            dependsOn(compose, validate)
-        }.apply {
-            if (plugins.hasPlugin(InstancePlugin::class.java)) {
-                val create = named<Task>(InstanceCreate.NAME)
-                val up = named<Task>(InstanceUp.NAME)
-                val satisfy = named<Task>(InstanceSatisfy.NAME)
-                val provision = named<Task>(InstanceProvision.NAME)
-                val setup = named<Task>(InstanceSetup.NAME)
-
-                configureApply {
-                    mustRunAfter(create, up, satisfy, provision, setup)
-                }
+        configurations.named(Dependency.ARCHIVES_CONFIGURATION) { it.extendsFrom(configuration) }
+        components.named(CommonPlugin.COMPONENT).configure { component ->
+            if (component is AdhocComponentWithVariants) {
+                component.addVariantsFromConfiguration(configuration) { it.mapToMavenScope(MavenScope.Runtime.lowerName) }
             }
         }
 
-        register<PackageDelete>(PackageDelete.NAME) {
-            dependsOn(compose, validate)
-            mustRunAfter(deploy, upload, install, activate, uninstall)
-        }
-        register<PackagePurge>(PackagePurge.NAME) {
-            dependsOn(compose, validate)
-            mustRunAfter(deploy, upload, install, activate, uninstall)
-        }
-        named<Task>(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) {
-            dependsOn(compose)
-        }
-        named<Task>(LifecycleBasePlugin.CHECK_TASK_NAME) {
-            dependsOn(validate)
-        }
-        typed<PackageTask> {
-            files.from(compose.map { it.archiveFile })
+        tasks {
+            val clean = named<Task>(LifecycleBasePlugin.CLEAN_TASK_NAME)
+            val prepare = register<PackagePrepare>(PackagePrepare.NAME) {
+                mustRunAfter(clean)
+            }
+            val compose = register<PackageCompose>(PackageCompose.NAME) {
+                dependsOn(prepare)
+                mustRunAfter(clean)
+                metaDir.convention(prepare.flatMap { it.metaDir })
+            }.apply {
+                configuration.outgoing.artifacts.add(LazyPublishArtifact(this))
+
+                afterEvaluate {
+                    if (plugins.hasPlugin(BundlePlugin::class.java)) {
+                        configureApply { installBundleProject(project.path) }
+                    }
+                }
+            }
+            val validate = register<PackageValidate>(PackageValidate.NAME) {
+                dependsOn(compose)
+                packages.from(compose.flatMap { it.archiveFile })
+            }
+            val upload = register<PackageUpload>(PackageUpload.NAME) {
+                dependsOn(compose, validate)
+            }
+            val install = register<PackageInstall>(PackageInstall.NAME) {
+                dependsOn(compose, validate)
+                mustRunAfter(upload)
+            }
+            val uninstall = register<PackageUninstall>(PackageUninstall.NAME) {
+                dependsOn(compose, validate)
+                mustRunAfter(upload, install)
+            }
+            val activate = register<PackageActivate>(PackageActivate.NAME) {
+                dependsOn(compose, validate)
+                mustRunAfter(upload, install)
+            }
+            val deploy = register<PackageDeploy>(PackageDeploy.NAME) {
+                dependsOn(compose, validate)
+            }.apply {
+                if (plugins.hasPlugin(InstancePlugin::class.java)) {
+                    val create = named<Task>(InstanceCreate.NAME)
+                    val up = named<Task>(InstanceUp.NAME)
+                    val satisfy = named<Task>(InstanceSatisfy.NAME)
+                    val provision = named<Task>(InstanceProvision.NAME)
+                    val setup = named<Task>(InstanceSetup.NAME)
+
+                    configureApply {
+                        mustRunAfter(create, up, satisfy, provision, setup)
+                    }
+                }
+            }
+
+            register<PackageDelete>(PackageDelete.NAME) {
+                dependsOn(compose, validate)
+                mustRunAfter(deploy, upload, install, activate, uninstall)
+            }
+            register<PackagePurge>(PackagePurge.NAME) {
+                dependsOn(compose, validate)
+                mustRunAfter(deploy, upload, install, activate, uninstall)
+            }
+            named<Task>(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) {
+                dependsOn(compose)
+            }
+            named<Task>(LifecycleBasePlugin.CHECK_TASK_NAME) {
+                dependsOn(validate)
+            }
+            typed<PackageTask> {
+                files.from(compose.map { it.archiveFile })
+            }
         }
     }
 
     companion object {
         const val ID = "com.cognifide.aem.package"
+
+        const val CONFIGURATION = "aemPackage"
     }
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
@@ -12,6 +12,9 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.component.AdhocComponentWithVariants
 import org.gradle.api.internal.artifacts.ArtifactAttributes
@@ -45,7 +48,7 @@ class PackagePlugin @Inject constructor(private val objectFactory: ObjectFactory
     @Suppress("LongMethod")
     private fun Project.setupTasks() {
         val configuration = configurations.create(CONFIGURATION) { c ->
-            c.attributes.attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage::class.java, Usage.JAVA_RUNTIME))
+            c.attributes.attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category::class.java, Category.LIBRARY))
             c.outgoing.attributes.attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.ZIP_TYPE)
         }
         configurations.named(Dependency.ARCHIVES_CONFIGURATION) { it.extendsFrom(configuration) }

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
@@ -1,7 +1,6 @@
 package com.cognifide.gradle.aem.pkg
 
 import com.cognifide.gradle.aem.AemExtension
-import com.cognifide.gradle.aem.bundle.BundlePlugin
 import com.cognifide.gradle.aem.common.CommonPlugin
 import com.cognifide.gradle.aem.common.tasks.PackageTask
 import com.cognifide.gradle.aem.instance.InstancePlugin

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
@@ -12,10 +12,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
-import org.gradle.api.attributes.Bundling
 import org.gradle.api.attributes.Category
-import org.gradle.api.attributes.LibraryElements
-import org.gradle.api.attributes.Usage
 import org.gradle.api.component.AdhocComponentWithVariants
 import org.gradle.api.internal.artifacts.ArtifactAttributes
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/PackagePlugin.kt
@@ -67,12 +67,6 @@ class PackagePlugin @Inject constructor(private val objectFactory: ObjectFactory
                 metaDir.convention(prepare.flatMap { it.metaDir })
             }.apply {
                 configuration.outgoing.artifacts.add(LazyPublishArtifact(this))
-
-                afterEvaluate {
-                    if (plugins.hasPlugin(BundlePlugin::class.java)) {
-                        configureApply { installBundleProject(project.path) }
-                    }
-                }
             }
             val validate = register<PackageValidate>(PackageValidate.NAME) {
                 dependsOn(compose)

--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/PackageCompose.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/PackageCompose.kt
@@ -2,6 +2,7 @@ package com.cognifide.gradle.aem.pkg.tasks
 
 import com.cognifide.gradle.aem.AemTask
 import com.cognifide.gradle.aem.aem
+import com.cognifide.gradle.aem.bundle.BundlePlugin
 import com.cognifide.gradle.aem.bundle.tasks.BundleCompose
 import com.cognifide.gradle.aem.common.instance.service.pkg.Package
 import com.cognifide.gradle.aem.common.pkg.PackageException
@@ -221,7 +222,9 @@ open class PackageCompose : ZipTask(), AemTask {
     }
 
     fun installBundle(dependencyNotation: Any, options: BundleInstalledResolved.() -> Unit = {}) {
-        definitions.add { bundlesInstalled.add(BundleInstalledResolved(this, dependencyNotation).apply(options)) }
+        definitions.add {
+            bundlesInstalled.add(BundleInstalledResolved(this, dependencyNotation).apply(options))
+        }
     }
 
     fun installBundleProject(projectPath: String, options: BundleInstalledBuilt.() -> Unit = {}) {
@@ -241,6 +244,8 @@ open class PackageCompose : ZipTask(), AemTask {
             bundlesInstalled.add(BundleInstalledBuilt(this, task).apply(options))
         }
     }
+
+    fun installBundleBuilt(options: BundleInstalledBuilt.() -> Unit = {}) = installBundleProject(project.path, options)
 
     private var definition: () -> Unit = {
         fromDefaults()


### PR DESCRIPTION
see discussion: #542 

@sabberworm almost done; see functional tests

todo only listing bundle dependencies in published pom.xml

edit: listing bundle dependencies not needed as of bundles should have only compileOnly dependencies; Gradle by default for regular jars is only listing implementation/api dependencies so nothing to change here.
