### PR TITLE
Remove cq:lastRolledout* attributes on sync

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/sync/Cleaner.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/pkg/tasks/sync/Cleaner.kt
@@ -73,6 +73,7 @@ class Cleaner(private val aem: AemExtension) {
                 "jcr:created*",
                 "jcr:isCheckedOut",
                 "cq:lastReplicat*",
+                "cq:lastRolledout*",
                 "dam:extracted",
                 "dam:assetState",
                 "dc:modified",


### PR DESCRIPTION
These attributes are added to Live Copy pages on every Rollout. We don't
want to keep them in the project repository after running `sync' task.