### PR TITLE
Replication agents API + instance management improvements

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/Instance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/Instance.kt
@@ -108,7 +108,9 @@ open class Instance(@Transient @get:JsonIgnore protected val aem: AemExtension) 
             ?: slingSettings[key]
 
     @get:JsonIgnore
-    val available: Boolean get() = systemProperties.isNotEmpty()
+    val available: Boolean get() = sync.status.available
+
+    fun checkAvailable(): Boolean = sync.status.checkAvailable()
 
     @get:JsonIgnore
     val zoneId: ZoneId get() = systemProperties["user.timezone"]?.let { ZoneId.of(it) }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstance.kt
@@ -98,6 +98,18 @@ class LocalInstance private constructor(aem: AemExtension) : Instance(aem) {
     val pid: Int get() = quickstartDir.resolve("conf/cq.pid")
             .takeIf { it.exists() }?.readText()?.trim()?.ifBlank { null }?.toInt() ?: 0
 
+    @get:JsonIgnore
+    val logsDir get() = quickstartDir.resolve("logs")
+
+    @get:JsonIgnore
+    val stdoutLog get() = logsDir.resolve("stdout.log")
+
+    @get:JsonIgnore
+    val errorLog get() = logsDir.resolve("error.log")
+
+    @get:JsonIgnore
+    val requestLog get() = logsDir.resolve("request.log")
+
     override val version: AemVersion
         get() {
             val remoteVersion = super.version
@@ -238,7 +250,7 @@ class LocalInstance private constructor(aem: AemExtension) : Instance(aem) {
         }
 
         // Ensure that 'logs' directory exists
-        quickstartDir.resolve("logs").mkdirs()
+        logsDir.mkdirs()
     }
 
     private fun unpackFiles() {

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/check/TimeoutCheck.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/check/TimeoutCheck.kt
@@ -1,6 +1,7 @@
 package com.cognifide.gradle.aem.common.instance.check
 
 import com.cognifide.gradle.aem.common.instance.InstanceException
+import com.cognifide.gradle.aem.common.instance.LocalInstance
 import com.cognifide.gradle.common.utils.Formats
 import java.util.concurrent.TimeUnit
 
@@ -23,7 +24,14 @@ class TimeoutCheck(group: CheckGroup) : DefaultCheck(group) {
 
     override fun check() {
         if (!instance.available && progress.stateTime >= unavailableTime.get()) {
-            throw InstanceException("Instance unavailable timeout reached '${Formats.duration(progress.stateTime)}' for $instance!")
+            val error = "Instance unavailable timeout reached '${Formats.duration(progress.stateTime)}' for $instance!"
+            if (instance is LocalInstance) {
+                throw InstanceException("$error\n\n" +
+                        "Troubleshoot by investigating log files:\n${instance.stdoutLog}\n${instance.errorLog}\n\n" +
+                        "When ports are already used ('bind failed: Address already in use'), try rebooting machine.")
+            } else {
+                throw InstanceException(error)
+            }
         }
 
         if (progress.stateTime >= stateTime.get()) {

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/provision/Provisioner.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/provision/Provisioner.kt
@@ -218,4 +218,18 @@ class Provisioner(val manager: InstanceManager) {
         sync { groovyConsole.evalScript(fileName, data) }
         options()
     }
+
+    fun configureReplicationAgent(location: String, name: String, props: Map<String, Any?>, options: Step.() -> Unit = {}) = step("configureReplicationAgent/$location/$name") {
+        description.set("Configuring replication agent on '$location' named '$name'")
+        sync { repository.save("/etc/replication/agents.$location/$name/jcr:content", props) }
+        options()
+    }
+
+    fun enableReplicationAgent(location: String, name: String, instance: Instance, options: Step.() -> Unit = {}) = configureReplicationAgent(location, name, mapOf(
+        "enabled" to true,
+        "userId" to instance.user,
+        "transportUri" to "${instance.httpUrl}/bin/receive?sling:authRequestLogin=1",
+        "transportUser" to instance.user,
+        "transportPassword" to instance.password
+    ), options)
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/provision/Provisioner.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/provision/Provisioner.kt
@@ -225,11 +225,20 @@ class Provisioner(val manager: InstanceManager) {
         options()
     }
 
+    fun enableReplicationAgent(location: String, name: String, options: Step.() -> Unit = {}) = configureReplicationAgent(location, name, mapOf("enabled" to true), options)
+
+    fun disableReplicationAgent(location: String, name: String, options: Step.() -> Unit = {}) = configureReplicationAgent(location, name, mapOf("enabled" to false), options)
+
+    fun enableReplicationAgent(location: String, name: String, transportUri: String, options: Step.() -> Unit = {}) = configureReplicationAgent(location, name, mapOf(
+            "enabled" to true,
+            "transportUri" to transportUri
+    ), options)
+
     fun enableReplicationAgent(location: String, name: String, instance: Instance, options: Step.() -> Unit = {}) = configureReplicationAgent(location, name, mapOf(
-        "enabled" to true,
-        "userId" to instance.user,
-        "transportUri" to "${instance.httpUrl}/bin/receive?sling:authRequestLogin=1",
-        "transportUser" to instance.user,
-        "transportPassword" to instance.password
+            "enabled" to true,
+            "transportUri" to "${instance.httpUrl}/bin/receive?sling:authRequestLogin=1",
+            "transportUser" to instance.user,
+            "transportPassword" to instance.password,
+            "userId" to instance.user
     ), options)
 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/repository/ReplicationAgent.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/repository/ReplicationAgent.kt
@@ -1,0 +1,55 @@
+package com.cognifide.gradle.aem.common.instance.service.repository
+
+import com.cognifide.gradle.aem.common.instance.Instance
+
+class ReplicationAgent(val page: Node) {
+
+    val name get() = page.name
+
+    val location get() = page.parent.name.substringAfter("agents.")
+
+    val pageContent get() = page.child("jcr:content")
+
+    val enabled get() = pageContent.properties.boolean("enabled")
+
+    fun toggle(flag: Boolean) = pageContent.saveProperty("enabled", flag)
+
+    fun enable() = toggle(true)
+
+    fun enable(transportUri: String) = configure(mapOf(
+            "enabled" to true,
+            "transportUri" to transportUri
+    ))
+
+    fun enable(instance: Instance) = configure(mapOf(
+            "enabled" to true,
+            "transportUri" to "${instance.httpUrl}/bin/receive?sling:authRequestLogin=1",
+            "transportUser" to instance.user,
+            "transportPassword" to instance.password,
+            "userId" to instance.user
+    ))
+
+    fun disable() = toggle(false)
+
+    fun configure(props: Map<String, Any?>) {
+        if (!page.exists) page.save(mapOf(
+                "jcr:primaryType" to "cq:Page"
+        ))
+        pageContent.save(if (!pageContent.exists) mapOf(
+                "jcr:primaryType" to "nt:unstructured",
+                "jcr:title" to name.capitalize(),
+                "sling:resourceType" to "cq/replication/components/agent",
+                "cq:template" to "/libs/cq/replication/templates/agent"
+        ) + props else props)
+    }
+
+    fun delete() = page.delete()
+
+    override fun toString() = "ReplicationAgent(location=$location, name=$name)"
+
+    companion object {
+        const val LOCATION_AUTHOR = "author"
+
+        const val LOCATION_PUBLISH = "publish"
+    }
+}

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/repository/Repository.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/repository/Repository.kt
@@ -91,6 +91,18 @@ class Repository(sync: InstanceSync) : InstanceService(sync) {
         throw RepositoryException("Malformed response after querying $criteria on $instance. Cause: ${e.message}", e)
     }
 
+    fun replicationAgent(name: String, location: String) = ReplicationAgent(node("/etc/replication/agents.$location/$name"))
+
+    fun replicationAgents(location: String): Sequence<ReplicationAgent> = node("/etc/replication/agents.$location").siblings()
+            .filter { it.type == "cq:Page" }
+            .map { ReplicationAgent(it) }
+
+    fun replicationAgents(): Sequence<ReplicationAgent> {
+        return replicationAgents(ReplicationAgent.LOCATION_AUTHOR) + replicationAgents(ReplicationAgent.LOCATION_PUBLISH)
+    }
+
+    val replicationAgents: List<ReplicationAgent> get() = replicationAgents().toList()
+
     private fun splitPath(path: String): Pair<String, String> {
         return path.substringBeforeLast("/") to path.substringAfterLast("/")
     }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/repository/Repository.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/repository/Repository.kt
@@ -91,7 +91,7 @@ class Repository(sync: InstanceSync) : InstanceService(sync) {
         throw RepositoryException("Malformed response after querying $criteria on $instance. Cause: ${e.message}", e)
     }
 
-    fun replicationAgent(name: String, location: String) = ReplicationAgent(node("/etc/replication/agents.$location/$name"))
+    fun replicationAgent(location: String, name: String) = ReplicationAgent(node("/etc/replication/agents.$location/$name"))
 
     fun replicationAgents(location: String): Sequence<ReplicationAgent> = node("/etc/replication/agents.$location").siblings()
             .filter { it.type == "cq:Page" }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/repository/Repository.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/repository/Repository.kt
@@ -93,7 +93,7 @@ class Repository(sync: InstanceSync) : InstanceService(sync) {
 
     fun replicationAgent(location: String, name: String) = ReplicationAgent(node("/etc/replication/agents.$location/$name"))
 
-    fun replicationAgents(location: String): Sequence<ReplicationAgent> = node("/etc/replication/agents.$location").siblings()
+    fun replicationAgents(location: String): Sequence<ReplicationAgent> = node("/etc/replication/agents.$location").children()
             .filter { it.type == "cq:Page" }
             .map { ReplicationAgent(it) }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/status/Status.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/status/Status.kt
@@ -16,6 +16,21 @@ import java.util.*
 class Status(sync: InstanceSync) : InstanceService(sync) {
 
     /**
+     * Check if instance was available at least once across whole build, fail-safe.
+     */
+    val available: Boolean get() = systemProperties.isNotEmpty()
+
+    /**
+     * On-demand checks instance availability.
+     */
+    fun checkAvailable(): Boolean = try {
+        readProperties(SYSTEM_PROPERTIES_PATH).isNotEmpty()
+    } catch (e: CommonException) {
+        logger.debug("Seems that instance is not available: $instance", e)
+        false
+    }
+
+    /**
      * System properties of instance read once across whole build, fail-safe.
      */
     val systemProperties: Map<String, String> get() = readPropertiesOnce(SYSTEM_PROPERTIES_PATH)

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/tasks/SyncFileTask.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/tasks/SyncFileTask.kt
@@ -41,7 +41,10 @@ open class SyncFileTask : AemDefaultTask() {
      * Check instance(s) condition after performing action related with synced file(s).
      */
     @Internal
-    val awaited = aem.obj.boolean { convention(true) }
+    val awaited = aem.obj.boolean {
+        convention(true)
+        aem.prop.boolean("syncFile.awaited")?.let { set(it) }
+    }
 
     private var awaitUpOptions: AwaitUpAction.() -> Unit = {}
 


### PR DESCRIPTION
# Replication agents API

see usage: https://github.com/Cognifide/aem-project-archetype/blob/master/src/main/archetype/build.gradle.kts#L118

```kotlin
aem {

    instance {
        provisioner { // https://github.com/Cognifide/gradle-aem-plugin/blob/master/docs/instance-plugin.md#task-instanceprovision
            deleteReplicationAgents() // optionally :)
            configureReplicationAgentAuthor("publish") { enable(publishInstance) }
            configureReplicationAgentPublish("flush") { enable("http://localhost:80/dispatcher/invalidate.cache") }
            deployPackage("com.neva.felix:search-webconsole-plugin:1.3.0")
        }
    }

}

```

# Instance management improvements

![image](https://user-images.githubusercontent.com/10673561/89261705-cd559880-d62e-11ea-965d-9f9a7083ce10.png)
