### PR TITLE
Soft instance down

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/Instance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/Instance.kt
@@ -32,11 +32,16 @@ open class Instance(@Transient @get:JsonIgnore protected val aem: AemExtension) 
 
     lateinit var httpUrl: String
 
-    @get:JsonIgnore
-    val httpPort: Int get() = InstanceUrl.parse(httpUrl).httpPort
+    private val httpUrlDetails get() = InstanceUrl.parse(httpUrl)
 
     @get:JsonIgnore
-    val httpBasicAuthUrl: String get() = InstanceUrl.parse(httpUrl).basicAuth(user, password)
+    val httpPort get() = httpUrlDetails.httpPort
+
+    @get:JsonIgnore
+    val httpHost get() = httpUrlDetails.httpHost
+
+    @get:JsonIgnore
+    val httpBasicAuthUrl: String get() = httpUrlDetails.basicAuth(user, password)
 
     open lateinit var user: String
 
@@ -117,9 +122,10 @@ open class Instance(@Transient @get:JsonIgnore protected val aem: AemExtension) 
             ?: slingSettings[key]
 
     @get:JsonIgnore
-    val available: Boolean get() = sync.status.available
+    val reachable: Boolean get() = sync.status.reachable
 
-    fun checkAvailable(): Boolean = sync.status.checkAvailable()
+    @get:JsonIgnore
+    val available: Boolean get() = sync.status.available
 
     @get:JsonIgnore
     val zoneId: ZoneId get() = systemProperties["user.timezone"]?.let { ZoneId.of(it) }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/InstanceUrl.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/InstanceUrl.kt
@@ -31,16 +31,17 @@ class InstanceUrl(raw: String) {
         }
     }
 
-    val httpPort: Int
-        get() = when {
-            config.port != -1 -> config.port
-            else -> {
-                when (config.protocol) {
-                    "https" -> HTTPS_PORT
-                    else -> HTTP_PORT
-                }
+    val httpHost: String get() = config.host
+
+    val httpPort: Int get() = when {
+        config.port != -1 -> config.port
+        else -> {
+            when (config.protocol) {
+                "https" -> HTTPS_PORT
+                else -> HTTP_PORT
             }
         }
+    }
 
     val id: String get() = type.name.toLowerCase()
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/check/TimeoutCheck.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/check/TimeoutCheck.kt
@@ -23,8 +23,8 @@ class TimeoutCheck(group: CheckGroup) : DefaultCheck(group) {
     val constantTime = aem.obj.long { convention(TimeUnit.MINUTES.toMillis(30)) }
 
     override fun check() {
-        if (!instance.available && progress.stateTime >= unavailableTime.get()) {
-            val error = "Instance unavailable timeout reached '${Formats.duration(progress.stateTime)}' for $instance!"
+        if (!instance.reachable && progress.stateTime >= unavailableTime.get()) {
+            val error = "Instance is unreachable! Timeout occurred after '${Formats.duration(progress.stateTime)}' for $instance!"
             if (instance is LocalInstance) {
                 throw InstanceException("$error\n\n" +
                         "Troubleshoot by investigating log files:\n${instance.stdoutLog}\n${instance.errorLog}\n\n" +

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/check/UnavailableCheck.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/check/UnavailableCheck.kt
@@ -12,13 +12,24 @@ class UnavailableCheck(group: CheckGroup) : DefaultCheck(group) {
     val utilisationTime = aem.obj.long { convention(TimeUnit.SECONDS.toMillis(15)) }
 
     override fun check() {
-        val bundleState = state(sync.osgiFramework.determineBundleState())
-        if (!bundleState.unknown) {
-            statusLogger.error(
+        if (instance.available) {
+            val bundleState = state(sync.osgiFramework.determineBundleState())
+            if (!bundleState.unknown) {
+                statusLogger.error(
                     "Bundles stable (${bundleState.stablePercent})",
                     "Bundles stable (${bundleState.stablePercent}). HTTP server still responding on $instance"
-            )
-            return
+                )
+                return
+            }
+        } else {
+            val reachableStatus = state(sync.status.checkReachableStatus())
+            if (reachableStatus >= 0) {
+                statusLogger.error(
+                    "Reachable ($reachableStatus)",
+                    "Reachable - status code ($reachableStatus). HTTP server still responding on $instance"
+                )
+                return
+            }
         }
 
         if (instance is LocalInstance) {

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/status/Status.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/service/status/Status.kt
@@ -10,7 +10,8 @@ import com.cognifide.gradle.common.utils.Patterns
 import java.util.*
 
 /**
- * Allows to read statuses available at Apache Felix Web Console.
+ * Allows to obtain instance status.
+ * Uses statuses available at Apache Felix Web Console.
  *
  * @see <https://felix.apache.org/documentation/subprojects/apache-felix-web-console.html>
  */


### PR DESCRIPTION
supplement for #814

after changing password e.g via:

`instance.default.password=xxx` to `instance.default.password=yyy`

and running `instanceRestart` AEMs will relaunch with a new admin password.

this improvement modifies a bit behavior of the task `instanceDown` so that it will work even without access to AEM through basic auth.