### PR TITLE
Instance HTTP url enumeration

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/IdType.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/IdType.kt
@@ -10,8 +10,13 @@ enum class IdType {
     val type: String get() = name.toLowerCase()
 
     val httpUrlDefault: String get() = when (this) {
-        AUTHOR -> InstanceUrl.AUTHOR_DEFAULT
-        PUBLISH -> InstanceUrl.PUBLISH_DEFAULT
+        AUTHOR -> InstanceUrl.HTTP_AUTHOR_DEFAULT
+        PUBLISH -> InstanceUrl.HTTP_PUBLISH_DEFAULT
+    }
+
+    val httpPortDefault: Int get() = when (this) {
+        AUTHOR -> InstanceUrl.HTTP_AUTHOR_PORT_DEFAULT
+        PUBLISH -> InstanceUrl.HTTP_PUBLISH_PORT_DEFAULT
     }
 
     companion object {

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/Instance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/Instance.kt
@@ -310,7 +310,7 @@ open class Instance(@Transient @get:JsonIgnore protected val aem: AemExtension) 
                 name
             }.distinct()
 
-            return instanceNames.fold(mutableListOf<Instance>()) { result, name ->
+            return instanceNames.sorted().fold(mutableListOf()) { result, name ->
                 val defaultProps = prefixedProperties(allProps, NAME_DEFAULT)
                 val props = defaultProps + prefixedProperties(allProps, "instance.$name")
                 if (props["httpUrl"].isNullOrBlank() && props["type"].isNullOrBlank()) {
@@ -319,7 +319,7 @@ open class Instance(@Transient @get:JsonIgnore protected val aem: AemExtension) 
                     result.add(singleFromProperties(aem, name, props, result))
                 }
                 result
-            }.sortedBy { it.name }
+            }
         }
 
         private fun prefixedProperties(allProps: Map<String, *>, prefix: String) = allProps.filterKeys {

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/Instance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/Instance.kt
@@ -286,9 +286,9 @@ open class Instance(@Transient @get:JsonIgnore protected val aem: AemExtension) 
 
         fun defaultPair(aem: AemExtension) = listOf(defaultAuthor(aem), defaultPublish(aem))
 
-        fun defaultAuthor(aem: AemExtension) = create(aem, InstanceUrl.AUTHOR_DEFAULT)
+        fun defaultAuthor(aem: AemExtension) = create(aem, InstanceUrl.HTTP_AUTHOR_DEFAULT)
 
-        fun defaultPublish(aem: AemExtension) = create(aem, InstanceUrl.PUBLISH_DEFAULT)
+        fun defaultPublish(aem: AemExtension) = create(aem, InstanceUrl.HTTP_PUBLISH_DEFAULT)
 
         fun parse(aem: AemExtension, str: String, configurer: Instance.() -> Unit = {}): List<Instance> {
             return (Formats.toList(str) ?: listOf()).map { create(aem, it, configurer) }
@@ -310,15 +310,15 @@ open class Instance(@Transient @get:JsonIgnore protected val aem: AemExtension) 
                 name
             }.distinct()
 
-            return instanceNames.mapNotNull { name ->
+            return instanceNames.fold(mutableListOf<Instance>()) { result, name ->
                 val defaultProps = prefixedProperties(allProps, NAME_DEFAULT)
                 val props = defaultProps + prefixedProperties(allProps, "instance.$name")
                 if (props["httpUrl"].isNullOrBlank() && props["type"].isNullOrBlank()) {
                     aem.logger.warn("Instance named '$name' must have property 'httpUrl' or 'type' defined!")
-                    null
                 } else {
-                    singleFromProperties(aem, name, props)
+                    result.add(singleFromProperties(aem, name, props, result))
                 }
+                result
             }.sortedBy { it.name }
         }
 
@@ -330,37 +330,45 @@ open class Instance(@Transient @get:JsonIgnore protected val aem: AemExtension) 
             result.apply { put(prop, value as String) }
         }
 
-        private fun singleFromProperties(aem: AemExtension, name: String, props: Map<String, String>) = when (typeProperty(props)) {
-            PhysicalType.LOCAL -> localFromProperties(aem, name, props)
-            PhysicalType.REMOTE -> remoteFromProperties(aem, name, props)
+        private fun singleFromProperties(aem: AemExtension, name: String, props: Map<String, String>, others: List<Instance>): Instance {
+            return when (props["type"]?.let { PhysicalType.of(it) } ?: PhysicalType.REMOTE) {
+                PhysicalType.LOCAL -> localFromProperties(aem, name, props, others)
+                PhysicalType.REMOTE -> remoteFromProperties(aem, name, props, others)
+            }
         }
 
-        private fun localFromProperties(aem: AemExtension, name: String, props: Map<String, String>) = LocalInstance.create(aem, httpUrlProperty(name, props)) {
-            this.name = name
-            props["enabled"]?.let { this.enabled = it.toBoolean() }
-            props["password"]?.let { this.password = it }
-            props["jvmOpts"]?.let { this.jvmOpts = it.split(" ") }
-            props["startOpts"]?.let { this.startOpts = it.split(" ") }
-            props["runModes"]?.let { this.runModes = it.split(",") }
-            props["debugPort"]?.let { this.debugPort = it.toInt() }
-            props["debugAddress"]?.let { this.debugAddress = it }
-            props["openPath"]?.let { this.openPath = it }
-            this.properties.putAll(props.filterKeys { !LOCAL_PROPS.contains(it) })
+        private fun localFromProperties(aem: AemExtension, name: String, props: Map<String, String>, others: List<Instance>): LocalInstance {
+            val httpUrl = props["httpUrl"] ?: httpUrlProperty(name, others)
+            return LocalInstance.create(aem, httpUrl) {
+                this.name = name
+                props["enabled"]?.let { this.enabled = it.toBoolean() }
+                props["password"]?.let { this.password = it }
+                props["jvmOpts"]?.let { this.jvmOpts = it.split(" ") }
+                props["startOpts"]?.let { this.startOpts = it.split(" ") }
+                props["runModes"]?.let { this.runModes = it.split(",") }
+                props["debugPort"]?.let { this.debugPort = it.toInt() }
+                props["debugAddress"]?.let { this.debugAddress = it }
+                props["openPath"]?.let { this.openPath = it }
+                this.properties.putAll(props.filterKeys { !LOCAL_PROPS.contains(it) })
+            }
         }
 
-        private fun remoteFromProperties(aem: AemExtension, name: String, props: Map<String, String>) = create(aem, httpUrlProperty(name, props)) {
-            this.name = name
-            props["enabled"]?.let { this.enabled = it.toBoolean() }
-            props["user"]?.let { this.user = it }
-            props["password"]?.let { this.password = it }
-            this.properties.putAll(props.filterKeys { !REMOTE_PROPS.contains(it) })
+        private fun remoteFromProperties(aem: AemExtension, name: String, props: Map<String, String>, others: List<Instance>): Instance {
+            val httpUrl = props["httpUrl"] ?: httpUrlProperty(name, others)
+            return create(aem, httpUrl) {
+                this.name = name
+                props["enabled"]?.let { this.enabled = it.toBoolean() }
+                props["user"]?.let { this.user = it }
+                props["password"]?.let { this.password = it }
+                this.properties.putAll(props.filterKeys { !REMOTE_PROPS.contains(it) })
+            }
         }
 
-        private fun typeProperty(props: Map<String, String>) = props["type"]
-                ?.let { PhysicalType.of(it) } ?: PhysicalType.REMOTE
-
-        private fun httpUrlProperty(name: String, props: Map<String, String>) = props["httpUrl"]
-                ?: IdType.byId(name.split("-")[1]).httpUrlDefault
+        private fun httpUrlProperty(name: String, others: List<Instance>): String {
+            val type = IdType.byId(name.split("-")[1])
+            val port = others.filter { it.type == type }.map { it.httpPort }.max()?.let { it + 1 } ?: type.httpPortDefault
+            return "${InstanceUrl.HTTP_HOST_DEFAULT}:$port"
+        }
     }
 }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/InstanceUrl.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/InstanceUrl.kt
@@ -74,9 +74,15 @@ class InstanceUrl(raw: String) {
 
     companion object {
 
-        const val AUTHOR_DEFAULT = "http://localhost:4502"
+        const val HTTP_HOST_DEFAULT = "http://localhost"
 
-        const val PUBLISH_DEFAULT = "http://localhost:4503"
+        const val HTTP_AUTHOR_PORT_DEFAULT = 4502
+
+        const val HTTP_PUBLISH_PORT_DEFAULT = 4503
+
+        const val HTTP_AUTHOR_DEFAULT = "$HTTP_HOST_DEFAULT:$HTTP_AUTHOR_PORT_DEFAULT"
+
+        const val HTTP_PUBLISH_DEFAULT = "$HTTP_HOST_DEFAULT:$HTTP_PUBLISH_PORT_DEFAULT"
 
         const val HTTPS_PORT = 443
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstance.kt
@@ -12,8 +12,7 @@ import com.cognifide.gradle.common.zip.ZipFile
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import org.apache.commons.io.FileUtils
-import org.apache.commons.lang3.JavaVersion
-import org.apache.commons.lang3.SystemUtils
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.internal.os.OperatingSystem
 import java.io.File
 import java.io.FileFilter
@@ -52,7 +51,7 @@ class LocalInstance private constructor(aem: AemExtension) : Instance(aem) {
 
     @get:JsonIgnore
     private val jvmDebugOpt: String get() = when {
-        SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9) ->
+          localManager.javaLauncher.get().metadata.languageVersion >= JavaLanguageVersion.of(9) ->
             "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$debugSocketAddress"
         else ->
             "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$debugPort"

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstanceManager.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstanceManager.kt
@@ -395,7 +395,7 @@ class LocalInstanceManager(internal val aem: AemExtension) : Serializable {
         }
 
         common.progress(downInstances.size) {
-            common.parallel.with(downInstances) {
+            downInstances.onEachApply {
                 increment("Starting instance '$name'") {
                     if (!created) {
                         logger.info("Instance not created, so it could not be up: $this")
@@ -462,7 +462,7 @@ class LocalInstanceManager(internal val aem: AemExtension) : Serializable {
         }
 
         common.progress(upInstances.size) {
-            common.parallel.with(upInstances) {
+            upInstances.onEachApply {
                 increment("Stopping instance '$name'") {
                     sync {
                         http.connectionTimeout.set(1000)


### PR DESCRIPTION
also might improve #647 ; instead of parallel start.script execution, GAP will do it sequentially because seems that AEM does not like it :/